### PR TITLE
docs: add contributor Shuren Qi

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ If you find Tnlearn useful, please cite it in your publications.
 
 # The Team
 
-Tnlearn is a work by [Meng Wang](https://github.com/NewT123-WM), [Juntong Fan](https://github.com/Juntongkuki), [Hanyu Pei](https://github.com/HanyuPei22), [Tieyun LI](https://github.com/MillenRosen), [Jingxiao Liao](https://github.com/asdvfghg), and [Fenglei Fan](https://github.com/FengleiFan).
+Tnlearn is a work by [Meng Wang](https://github.com/NewT123-WM), [Juntong Fan](https://github.com/Juntongkuki), [Hanyu Pei](https://github.com/HanyuPei22), [Tieyun LI](https://github.com/MillenRosen), [Jingxiao Liao](https://github.com/asdvfghg), [Fenglei Fan](https://github.com/FengleiFan), and [Shuren Qi](https://github.com/ShurenQi).
 
 # License
 


### PR DESCRIPTION
## Summary

- Add Shuren Qi to the README's **The Team** section.
- Link the contributor entry to https://github.com/ShurenQi.

## Testing

- Not applicable (documentation-only change).