### PR TITLE
feat: Add InnerProduct operator and mode-based architecture enhancements

### DIFF
--- a/benchmark/classification/benchmark_1.py
+++ b/benchmark/classification/benchmark_1.py
@@ -46,6 +46,7 @@ params = {
     "max_iter": 400,
     "batch_size": 128,
     "lr": 0.01,
+    "mode": 'legacy',
 
 }
 

--- a/benchmark/classification/benchmark_2.py
+++ b/benchmark/classification/benchmark_2.py
@@ -46,6 +46,7 @@ params = {
     "max_iter": 400,
     "batch_size": 128,
     "lr": 0.01,
+    "mode": 'legacy',
 
 }
 

--- a/benchmark/classification/benchmark_3.py
+++ b/benchmark/classification/benchmark_3.py
@@ -46,6 +46,7 @@ params = {
     "max_iter": 400,
     "batch_size": 256,
     "lr": 0.01,
+    "mode": 'legacy',
 
 }
 

--- a/benchmark/image_benchmark_polyregressor/TC_Googlenet.py
+++ b/benchmark/image_benchmark_polyregressor/TC_Googlenet.py
@@ -21,7 +21,7 @@ class Inception(nn.Module):
 
         #1x1conv branch
         self.b1 = nn.Sequential(
-            TNConv2d(input_channels, n1x1, kernel_size=1, symbolic_expression='x + torch.sin(x)'),
+            TNConv2d(input_channels, n1x1, kernel_size=1, symbolic_expression='x + sin(x)'),
             # nn.Conv2d(input_channels, n1x1, kernel_size=1),
             nn.BatchNorm2d(n1x1),
             nn.ReLU(inplace=True)
@@ -71,7 +71,7 @@ class GoogleNet(nn.Module):
     def __init__(self, num_class=100):
         super().__init__()
         self.prelayer = nn.Sequential(
-            TNConv2d(3, 64, kernel_size=3, padding=1, bias=False, symbolic_expression='x + torch.sin(x)'),
+            TNConv2d(3, 64, kernel_size=3, padding=1, bias=False, symbolic_expression='x + sin(x)'),
             # nn.Conv2d(3, 64, kernel_size=3, padding=1, bias=False),
             nn.BatchNorm2d(64),
             nn.ReLU(inplace=True),

--- a/benchmark/image_benchmark_polyregressor/TC_Resnet.py
+++ b/benchmark/image_benchmark_polyregressor/TC_Resnet.py
@@ -32,7 +32,7 @@ class BasicBlock(nn.Module):
         self.residual_function = nn.Sequential(
             TNConv2d(
                 in_channels, out_channels, kernel_size=3,
-                symbolic_expression='x + torch.sin(x)',
+                symbolic_expression='x + sin(x)',
                 bias=False
             ),
             # nn.Conv2d(in_channels, out_channels, kernel_size=3, stride=stride, padding=1, bias=False),
@@ -67,7 +67,7 @@ class BottleNeck(nn.Module):
         self.residual_function = nn.Sequential(
             TNConv2d(
                 in_channels,out_channels, kernel_size=1,
-                symbolic_expression='x + torch.sin(x)',
+                symbolic_expression='x + sin(x)',
                 bias=False
             ),
             # nn.Conv2d(in_channels, out_channels, kernel_size=1, bias=False),
@@ -99,7 +99,7 @@ class ResNet(nn.Module):
         self.in_channels = 64
 
         self.conv1 = nn.Sequential(
-            TNConv2d(3, 64, kernel_size=3, padding=1, symbolic_expression='x + torch.sin(x)', bias=False),
+            TNConv2d(3, 64, kernel_size=3, padding=1, symbolic_expression='x + sin(x)', bias=False),
             # nn.Conv2d(3, 64, kernel_size=3, padding=1, bias=False),
             nn.BatchNorm2d(64),
             nn.ReLU(inplace=True))

--- a/benchmark/image_benchmark_polyregressor/TC_densenet.py
+++ b/benchmark/image_benchmark_polyregressor/TC_densenet.py
@@ -34,7 +34,7 @@ class Bottleneck(nn.Module):
         self.bottle_neck = nn.Sequential(
             nn.BatchNorm2d(in_channels),
             nn.ReLU(inplace=True),
-            TNConv2d(in_channels, inner_channel, kernel_size=1, symbolic_expression='x + torch.sin(x)', bias=True),
+            TNConv2d(in_channels, inner_channel, kernel_size=1, symbolic_expression='x + sin(x)', bias=True),
             # nn.Conv2d(in_channels, inner_channel, kernel_size=1, bias=False),
             nn.BatchNorm2d(inner_channel),
             nn.ReLU(inplace=True),
@@ -79,7 +79,7 @@ class DenseNet(nn.Module):
         #side of the inputs is zero-padded by one pixel to keep
         #the feature-map size fixed.
         # self.conv1 = nn.Conv2d(3, inner_channels, kernel_size=3, padding=1, bias=False)
-        self.conv1 = TNConv2d(3, inner_channels, kernel_size=3, padding=1, symbolic_expression='x + torch.sin(x)', bias=False)
+        self.conv1 = TNConv2d(3, inner_channels, kernel_size=3, padding=1, symbolic_expression='x + sin(x)', bias=False)
         self.features = nn.Sequential()
 
         for index in range(len(nblocks) - 1):

--- a/benchmark/image_benchmark_polyregressor/TC_senet.py
+++ b/benchmark/image_benchmark_polyregressor/TC_senet.py
@@ -68,7 +68,7 @@ class BottleneckResidualSEBlock(nn.Module):
         super().__init__()
 
         self.residual = nn.Sequential(
-            TNConv2d(in_channels, out_channels, 1, symbolic_expression='x + torch.sin(x)'),
+            TNConv2d(in_channels, out_channels, 1, symbolic_expression='x + sin(x)'),
             # nn.Conv2d(in_channels, out_channels, 1),
             nn.BatchNorm2d(out_channels),
             nn.ReLU(inplace=True),
@@ -119,7 +119,7 @@ class SEResNet(nn.Module):
         self.in_channels = 64
 
         self.pre = nn.Sequential(
-            TNConv2d(3, 64, 3, padding=1, symbolic_expression='x + torch.sin(x)', bias=True),
+            TNConv2d(3, 64, 3, padding=1, symbolic_expression='x + sin(x)', bias=True),
             # nn.Conv2d(3, 64, 3, padding=1),
             nn.BatchNorm2d(64),
             nn.ReLU(inplace=True)

--- a/benchmark/regression/benchmark_1.py
+++ b/benchmark/regression/benchmark_1.py
@@ -47,6 +47,7 @@ params = {
     "max_iter": 100,
     "batch_size": 10,
     "lr": 0.01,
+    "mode": 'legacy',
 }
 
 clf = MLPRegressor(**params)

--- a/benchmark/regression/benchmark_2.py
+++ b/benchmark/regression/benchmark_2.py
@@ -46,6 +46,7 @@ params = {
     "max_iter": 300,
     "batch_size": 10,
     "lr": 0.01,
+    "mode": 'legacy',
 }
 
 clf = MLPRegressor(**params)

--- a/benchmark/regression/benchmark_3.py
+++ b/benchmark/regression/benchmark_3.py
@@ -46,6 +46,7 @@ params = {
     "max_iter": 300,
     "batch_size": 128,
     "lr": 0.01,
+    "mode": 'legacy',
 }
 
 clf = MLPRegressor(**params)

--- a/examples/example_classification.py
+++ b/examples/example_classification.py
@@ -42,6 +42,7 @@ clf = MLPClassifier(
     #            'gamma': 0.2},
     l1_reg=False,
     l2_reg=False,
+    mode='legacy',
 )
 
 clf.fit(X, y)

--- a/examples/example_drsr.py
+++ b/examples/example_drsr.py
@@ -6,7 +6,8 @@ Data: y = 3 * x^2 + 2 * x + noise
 import numpy as np
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import r2_score
-from tnlearn import LLMSymRegressor, MLPRegressor
+from tnlearn import LLMSymRegressor
+from tnlearn.mlpregressor import MLPRegressor
 
 # ============================================================================
 # 1. Generate synthetic data (univariate, polynomial with noise)
@@ -32,7 +33,8 @@ reg = LLMSymRegressor(
     max_iterations=3,
     samples_per_iteration=4,
     verbose=1,          # 0=quiet, 1=basic progress, 2=debug
-    extra_prompt='Polynomial is preferred'
+    extra_prompt='Polynomial is preferred',
+    mode = 'base'
 )
 print("Training LLMSymRegressor to discover the underlying formula...")
 reg.fit(X_train, y_train)
@@ -42,19 +44,20 @@ print("\n" + "="*60)
 print("Discovered equation body (with param placeholders):")
 print(reg.best_equation_)
 print("\nNeuron formula (with optimized coefficients):")
-print(reg.get_neuron_formula())
+print(reg.neuron)
 print("="*60)
 
 # ============================================================================
 # 3. Build MLPRegressor using the discovered neuron formula
 # ============================================================================
 mlp_custom = MLPRegressor(
-    neurons=reg.get_neuron_formula(),   # Use the discovered neuron
+    neurons=reg.neuron,   # Use the discovered neuron
     layers_list=[20, 10],               # Two hidden layers
     activation_funcs='relu',
     max_iter=300,
     batch_size=64,
     lr=0.001,
+    mode = 'base'
 )
 print("\nTraining MLP with the discovered neuron...")
 mlp_custom.fit(X_train, y_train)

--- a/examples/example_regression.py
+++ b/examples/example_regression.py
@@ -47,6 +47,7 @@ clf = MLPRegressor(
     #            'gamma': 0.2},
     l1_reg=False,
     l2_reg=False,
+    mode='legacy',
 )
 
 clf.fit(X, y)

--- a/examples/example_rl_regression.py
+++ b/examples/example_rl_regression.py
@@ -1,60 +1,26 @@
-"""
-Example: Using RLRegressor to discover a symbolic expression and building an MLP with it.
-
-Data is generated as: y = 4*x^2 + 3*x - 5 + sin(x) + noise.
-RLRegressor learns to select a subset of polynomial and trigonometric basis functions.
-The discovered expression is then used as a neuron formula in MLPRegressor.
-"""
-
 import numpy as np
-from sklearn.model_selection import train_test_split
-from sklearn.metrics import r2_score
+from tnlearn.rl_regressor import RLSymRegressor
 
-from tnlearn.rl_regressor import RLRegressor
-from tnlearn import MLPRegressor
+np.random.seed(42)
+n_samples, n_features = 300, 5
+X = np.random.randn(n_samples, n_features)
+sum_x = np.sum(X, axis=1)
+y = np.sum(X**2, axis=1) + 0.5 * sum_x**2 + 2 * X[:, 0] + 0.1 * np.random.randn(n_samples)
 
-# ============================================================================
-# 1. Generate synthetic data (mixed polynomial and trigonometric)
-# ============================================================================
-np.random.seed(1)
-n_samples = 500
-X = np.random.uniform(-2, 2, (n_samples, 1))
-y = 4 * X[:, 0] ** 2 + 3 * X[:, 0] - 5 + np.sin(X[:, 0]) + 0.1 * np.random.randn(n_samples)
-
-X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=1)
-
-# ============================================================================
-# 2. Train RLRegressor to discover the underlying expression
-# ============================================================================
-rl = RLRegressor(
+reg = RLSymRegressor(
+    max_power=4,
+    max_terms_psi=3,
+    alpha=0.1,
     random_state=42,
-    max_episodes=200,          # Keep low for demonstration; increase for better results
-    max_power=3,
-    max_terms=3,
-    basis_mode='trigonometric',  # Use trigonometric basis functions
+    max_episodes=50,
     val_split=0.2,
+    lr_rl=1e-3,
+    gamma=0.99,
+    hidden_dim=64,
+    max_terms_total=4,
     verbose=True,
 )
-rl.fit(X_train, y_train)
 
-expr = rl.get_neuron()
-print(f"\nDiscovered expression: {expr}")
-
-# ============================================================================
-# 3. Build an MLP using the discovered neuron formula
-# ============================================================================
-mlp = MLPRegressor(
-    neurons=expr,
-    layers_list=[50, 30, 10],
-    activation_funcs='sigmoid',
-    max_iter=1000,
-    batch_size=64,
-    lr=0.001,
-    random_state=1,
-    visual=False,
-)
-mlp.fit(X_train, y_train)
-y_pred = mlp.predict(X_test)
-r2 = r2_score(y_test, y_pred)
-
-print(f"\nMLP with discovered neuron - Test R²: {r2:.4f}")
+reg.fit(X, y)
+print("\n最佳表达式 (pretty):", reg.neuron)
+print("验证 R²:", reg.best_score)

--- a/examples/regressor.py
+++ b/examples/regressor.py
@@ -1,8 +1,8 @@
 import h5py
-from tnlearn import VecSymRegressor
+from tnlearn import GPSymRegressor
 import numpy as np
 
-neuron = VecSymRegressor(random_state=100,
+neuron = GPSymRegressor(random_state=100,
                          pop_size=500,
                          max_generations=20,
                          tournament_size=10,

--- a/tests/test_mlpclassifier.py
+++ b/tests/test_mlpclassifier.py
@@ -39,6 +39,7 @@ mlp = MLPClassifier(neurons='x**2',
                     optimizer_name='adam',
                     max_iter=200,
                     batch_size=16,
+                    mode='lagacy'
                     )
 
 # Training the MLPClassifier using the training data.

--- a/tests/test_mlpregressor.py
+++ b/tests/test_mlpregressor.py
@@ -43,6 +43,7 @@ mlp_regressor = MLPRegressor(neurons='x**2',
                              optimizer_name='adam',
                              max_iter=200,
                              batch_size=16,
+                             mode='lagacy'
                              )
 
 # Train the MLP regressor model on the preprocessed training data

--- a/tests/test_regressor.py
+++ b/tests/test_regressor.py
@@ -1,28 +1,28 @@
 """
-Program name: VecSymRegressor Class Testing
-Purpose description: This program is for unit testing the VecSymRegressor class, ensuring the correctness
-                     of its evaluation, simplification, and random weight generation methods. The VecSymRegressor
+Program name: GPSymRegressor Class Testing
+Purpose description: This program is for unit testing the GPSymRegressor class, ensuring the correctness
+                     of its evaluation, simplification, and random weight generation methods. The GPSymRegressor
                      class utilizes evolutionary algorithms for regression tasks, and this testing suite
                      aims to verify functional integrity across its methods using predefined conditions and parameters.
-Tests: This test suite covers the main functional aspects of the VecSymRegressor class using simple assertions
+Tests: This test suite covers the main functional aspects of the GPSymRegressor class using simple assertions
        and is not reliant on synthetic datasets from sklearn's make_regression.
-Note: This testing program assumes the correct implementation of a hypothetical VecSymRegressor class which is
+Note: This testing program assumes the correct implementation of a hypothetical GPSymRegressor class which is
       not part of the sklearn library. It specifically checks that the methods behave as expected when
       called with reasonable inputs.
 """
 
 import unittest
 import numpy as np
-from tnlearn import VecSymRegressor
+from tnlearn import GPSymRegressor
 
 
-# Custom VecSymRegressor testing class inheriting from TestCase in the unittest module
+# Custom GPSymRegressor testing class inheriting from TestCase in the unittest module
 class TestRegressor(unittest.TestCase):
 
     # Set up function to initialize the regressor object before each test
     def setUp(self):
-        # The VecSymRegressor is initialized with various hyperparameters
-        self.regressor = VecSymRegressor(random_state=100,
+        # The GPSymRegressor is initialized with various hyperparameters
+        self.regressor = GPSymRegressor(random_state=100,
                                          pop_size=5000,
                                          max_generations=30,
                                          tournament_size=10,

--- a/tests/test_tncnn.py
+++ b/tests/test_tncnn.py
@@ -56,7 +56,7 @@ models = []
 inputs = []
 
 # 1. TNLinear
-linear = TNLinear(10, 5, symbolic_expression='x**2+3@torch.sin(x)', bias=True)
+linear = TNLinear(10, 5, symbolic_expression='x**2+3*sin(x)', bias=True)
 x_lin = torch.randn(3, 10)
 y_lin = linear(x_lin)
 print(f"Linear output shape: {y_lin.shape}")
@@ -70,7 +70,7 @@ conv1d = TNConv1d(
     kernel_size=5,
     stride=2,
     padding=1,
-    symbolic_expression='x + torch.sin(x)',
+    symbolic_expression='x + sin(x)',
     padding_mode='reflect'
 )
 x_c1 = torch.randn(2, 3, 100)
@@ -86,7 +86,7 @@ conv2d = TNConv2d(
     kernel_size=3,
     stride=1,
     padding=1,
-    symbolic_expression='x + 0.5@x**2',
+    symbolic_expression='x + 0.5*x**2',
     groups=1,
     dilation=2,
     padding_mode='zeros'
@@ -135,7 +135,7 @@ conv_transpose2d = TNConvTranspose2d(
     kernel_size=4,
     stride=2,
     padding=1,
-    symbolic_expression='x + torch.sin(x)'
+    symbolic_expression='x + sin(x)'
 )
 x_ct2 = torch.randn(1, 3, 32, 32)
 y_ct2 = conv_transpose2d(x_ct2)
@@ -150,7 +150,7 @@ conv_transpose3d = TNConvTranspose3d(
     kernel_size=3,
     stride=2,
     padding=1,
-    symbolic_expression='x + 0.5@x**2'
+    symbolic_expression='x + 0.5*x**2'
 )
 x_ct3 = torch.randn(1, 8, 16, 32, 32)
 y_ct3 = conv_transpose3d(x_ct3)

--- a/tests/test_tnrnn.py
+++ b/tests/test_tnrnn.py
@@ -113,13 +113,13 @@ def test_save_load(model, input_args, hx_args=None, is_cell=False):
 def test_rnn_models():
     # 1. TNRNN
     model = TNRNN(input_size=10, hidden_size=20, num_layers=2, batch_first=True,
-                  symbolic_expression='x + 0.5@torch.sin(x)')
+                  symbolic_expression='x + 0.5*sin(x)')
     x = torch.randn(3, 5, 10)  # (batch, seq, feature)
     test_save_load(model, x)
 
     # 2. TNLSTM
     model = TNLSTM(input_size=10, hidden_size=20, num_layers=2, bidirectional=True,
-                   symbolic_expression='x**2 + torch.cos(x)')
+                   symbolic_expression='x**2 + cos(x)')
     x = torch.randn(3, 5, 10)
     test_save_load(model, x)
 
@@ -131,7 +131,7 @@ def test_rnn_models():
 
     # 4. TNRNNCell
     cell = TNRNNCell(input_size=10, hidden_size=20, nonlinearity='relu',
-                     symbolic_expression='x + torch.sin(x)')
+                     symbolic_expression='x + sin(x)')
     x_t = torch.randn(3, 10)
     h = torch.randn(3, 20)
     test_save_load(cell, x_t, hx_args=h, is_cell=True)
@@ -146,7 +146,7 @@ def test_rnn_models():
 
     # 6. TNGRUCell
     cell = TNGRUCell(input_size=10, hidden_size=20,
-                     symbolic_expression='x + 0.1@torch.exp(x)*x**2')
+                     symbolic_expression='x + 0.1*exp(x)*x**2')
     x_t = torch.randn(3, 10)
     h = torch.randn(3, 20)
     test_save_load(cell, x_t, hx_args=h, is_cell=True)

--- a/tests/test_tntransformer.py
+++ b/tests/test_tntransformer.py
@@ -1,6 +1,14 @@
+"""
+Full test script for TNTransformer components with serialization support.
+
+This script tests all Transformer modules using torch.save/load.
+It assumes TNLinear has been patched with __getstate__/__setstate__.
+"""
+
 import torch
 import tempfile
 import os
+from typing import Optional, Tuple, List, Union, Any
 from tnlearn import (
     TNTransformer,
     TNTransformerEncoder,
@@ -10,6 +18,7 @@ from tnlearn import (
 )
 
 
+# ---------- Helper: compare tensors ----------
 def compare_tensors(out1, out2, atol=1e-6):
     """Recursively compare two outputs, supporting nested tuples/lists."""
     if isinstance(out1, torch.Tensor):
@@ -22,26 +31,22 @@ def compare_tensors(out1, out2, atol=1e-6):
         raise TypeError(f"Unsupported type: {type(out1)}")
 
 
+# ---------- Save/load test using torch.save/load ----------
 def test_model_save_load(model, args, kwargs=None):
     """
-    Generic save-load test.
-
-    Args:
-        model: The model to test.
-        args:  Positional arguments to pass to forward.
-        kwargs: Keyword arguments to pass to forward (optional).
+    Generic save-load test using torch.save/load (requires model picklable).
     """
     model.train()
     optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
 
-    # Forward and backward update
+    # Forward + backward
     optimizer.zero_grad()
     if kwargs is None:
         output = model(*args)
     else:
         output = model(*args, **kwargs)
 
-    # Sum outputs as loss (supports nested outputs)
+    # Loss
     def sum_output(out):
         if isinstance(out, torch.Tensor):
             return out.sum()
@@ -54,7 +59,7 @@ def test_model_save_load(model, args, kwargs=None):
     loss.backward()
     optimizer.step()
 
-    # Record the output after update (eval mode)
+    # Record output after update
     model.eval()
     with torch.no_grad():
         if kwargs is None:
@@ -62,20 +67,19 @@ def test_model_save_load(model, args, kwargs=None):
         else:
             out_after = model(*args, **kwargs)
 
-    # Save the full model
+    # Save full model
     with tempfile.NamedTemporaryFile(delete=False, suffix='.pt') as f:
         torch.save(model, f.name)
         path = f.name
 
-    # Load the model (compatible with older PyTorch)
+    # Load model
     try:
         loaded_model = torch.load(path, weights_only=False)
     except TypeError:
         loaded_model = torch.load(path)
-
     loaded_model.eval()
 
-    # Compare outputs before and after loading
+    # Compare outputs
     with torch.no_grad():
         if kwargs is None:
             out_loaded = loaded_model(*args)
@@ -84,7 +88,7 @@ def test_model_save_load(model, args, kwargs=None):
 
     compare_tensors(out_after, out_loaded, atol=1e-6)
 
-    # Compare all parameters
+    # Compare parameters (optional, but good to verify)
     for (name1, p1), (name2, p2) in zip(model.state_dict().items(), loaded_model.state_dict().items()):
         assert torch.allclose(p1, p2, atol=1e-6), f"Parameter mismatch for {name1}"
 
@@ -92,67 +96,106 @@ def test_model_save_load(model, args, kwargs=None):
     os.unlink(path)
 
 
+# ---------- Main test function ----------
 def test_transformer_models():
-    # Fix random seed for reproducibility
+    """Test all Transformer components with TNLinear."""
     torch.manual_seed(42)
 
     # ---------- 1. TNTransformerEncoderLayer ----------
-    # batch_first=False (default)
+    print("Testing TNTransformerEncoderLayer (batch_first=False)...")
     encoder_layer = TNTransformerEncoderLayer(
         d_model=512, nhead=8, dim_feedforward=2048,
         dropout=0.1, activation='relu',
-        symbolic_expression='x + torch.sin(x)'
+        symbolic_expression='x + sin(x)'
     )
     src = torch.randn(10, 32, 512)   # (seq, batch, feature)
-    # forward signature: (src, src_mask=None, src_key_padding_mask=None, is_causal=False)
     test_model_save_load(encoder_layer, (src,))
 
+    # batch_first=True
+    print("Testing TNTransformerEncoderLayer (batch_first=True)...")
+    encoder_layer_bf = TNTransformerEncoderLayer(
+        d_model=512, nhead=8, dim_feedforward=2048,
+        dropout=0.1, activation='gelu',
+        batch_first=True,
+        symbolic_expression='x**2 + cos(x)'
+    )
+    src_bf = torch.randn(32, 10, 512)  # (batch, seq, feature)
+    test_model_save_load(encoder_layer_bf, (src_bf,))
+
     # ---------- 2. TNTransformerDecoderLayer ----------
+    print("Testing TNTransformerDecoderLayer...")
     decoder_layer = TNTransformerDecoderLayer(
         d_model=512, nhead=8, dim_feedforward=2048,
         dropout=0.1, activation='gelu',
-        symbolic_expression='x**2 + torch.cos(x)'
+        symbolic_expression='x * sin(x)'
     )
     tgt = torch.randn(20, 32, 512)
     memory = torch.randn(10, 32, 512)
-    # forward signature: (tgt, memory, tgt_mask=None, memory_mask=None, ...)
     test_model_save_load(decoder_layer, (tgt, memory))
 
-    # ---------- 3. TNTransformerEncoder ----------
-    # Stack 2 layers with LayerNorm
+    # ---------- 3. TNTransformerEncoder (stack) ----------
+    print("Testing TNTransformerEncoder...")
     enc_layer = TNTransformerEncoderLayer(
         d_model=512, nhead=8, dim_feedforward=2048,
         dropout=0.1, activation='relu',
-        symbolic_expression='x + 0.5 * torch.sin(x)'
+        symbolic_expression='x + 0.5 * sin(x)'
     )
     encoder = TNTransformerEncoder(enc_layer, num_layers=2)
     src = torch.randn(10, 32, 512)
     test_model_save_load(encoder, (src,))
 
-    # ---------- 4. TNTransformerDecoder ----------
+    # ---------- 4. TNTransformerDecoder (stack) ----------
+    print("Testing TNTransformerDecoder...")
     dec_layer = TNTransformerDecoderLayer(
         d_model=512, nhead=8, dim_feedforward=2048,
         dropout=0.1, activation='gelu',
-        symbolic_expression='x * torch.sigmoid(x)'
+        symbolic_expression='x * tanh(x)'
     )
     decoder = TNTransformerDecoder(dec_layer, num_layers=2)
     tgt = torch.randn(20, 32, 512)
     memory = torch.randn(10, 32, 512)
     test_model_save_load(decoder, (tgt, memory))
 
-    # ---------- 5. TNTransformer (full model) ----------
+    # ---------- 5. Full TNTransformer ----------
+    print("Testing TNTransformer (full model)...")
     transformer = TNTransformer(
         d_model=512, nhead=8,
         num_encoder_layers=2, num_decoder_layers=2,
         dim_feedforward=2048, dropout=0.1,
         activation='relu',
-        symbolic_expression='x + torch.tanh(x)',
-        batch_first=False  # default
+        symbolic_expression='x + tanh(x)',
+        batch_first=False
     )
     src = torch.randn(10, 32, 512)
     tgt = torch.randn(20, 32, 512)
-    # forward has many optional args; pass only required src, tgt
     test_model_save_load(transformer, (src, tgt))
+
+    # ---------- 6. Test with masks and batch_first=True ----------
+    print("Testing TNTransformer with masks and batch_first=True...")
+    transformer_bf = TNTransformer(
+        d_model=512, nhead=8,
+        num_encoder_layers=2, num_decoder_layers=2,
+        dim_feedforward=2048, dropout=0.1,
+        activation='gelu',
+        symbolic_expression='x + 0.1*sin(x)',
+        batch_first=True
+    )
+    src_bf = torch.randn(32, 10, 512)
+    tgt_bf = torch.randn(32, 20, 512)
+
+    tgt_mask = transformer_bf.generate_square_subsequent_mask(20)
+    src_key_padding_mask = torch.randint(0, 2, (32, 10)).bool()
+    tgt_key_padding_mask = torch.randint(0, 2, (32, 20)).bool()
+
+    test_model_save_load(
+        transformer_bf,
+        (src_bf, tgt_bf),
+        kwargs={
+            'tgt_mask': tgt_mask,
+            'src_key_padding_mask': src_key_padding_mask,
+            'tgt_key_padding_mask': tgt_key_padding_mask
+        }
+    )
 
     print("All Transformer tests passed! ✅")
 

--- a/tnlearn/__init__.py
+++ b/tnlearn/__init__.py
@@ -16,7 +16,7 @@
 
 __version__ = '0.2.0.dev0'
 
-from tnlearn.regressor import VecSymRegressor
+from tnlearn.gp_regressor import GPSymRegressor, VecSymRegressor
 from tnlearn.mlpregressor import MLPRegressor
 from tnlearn.mlpclassifier import MLPClassifier
 from tnlearn.preprocessing import DataPreprocessor
@@ -25,21 +25,23 @@ from tnlearn.base1 import BaseModel1
 from tnlearn.poly_regressor import PolyTensorRegression
 
 from tnlearn.drsr import LLMSymRegressor
-from tnlearn.rl_regressor import RLRegressor
+from tnlearn.rl_regressor import RLRegressor, RLSymRegressor
 
 from tnlearn.modules import *
 from tnlearn import modules
 
 __all__ = [
-    'VecSymRegressor',
+    'GPSymRegressor',
+    'VecSymRegressor', # legacy
     'MLPRegressor',
     'MLPClassifier',
     'DataPreprocessor',
     'BaseModel',
     'BaseModel1',
-    'PolyTensorRegression',
+    'PolyTensorRegression', # about to be deprecated
     'LLMSymRegressor',           
-    'RLRegressor',              
+    'RLRegressor', # legacy
+    'RLSymRegressor',                   
 ]
 
 if hasattr(modules, '__all__'):

--- a/tnlearn/drsr/__init__.py
+++ b/tnlearn/drsr/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Meng WANG. All Rights Reserved.
+# Copyright 2026 Tieyun LI. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tnlearn/drsr/agent.py
+++ b/tnlearn/drsr/agent.py
@@ -1,3 +1,4 @@
+# drsr/agent.py
 # Copyright 2023 DeepMind Technologies Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +16,6 @@
 # This file is based on the DRSR project (https://github.com/scientific-intelligent-modelling/drsr)
 # and has been modified for vectorized symbolic regression.
 
-# drsr/agent.py
 from __future__ import annotations
 import os
 import json
@@ -27,7 +27,8 @@ from . import pipeline
 from . import config as config_lib
 from . import sampler
 from . import evaluator
-from .template import SINGLE_VAR_TEMPLATE
+from .template import SINGLE_VAR_TEMPLATE_BASE, SINGLE_VAR_TEMPLATE_LEGACY
+from ..operator.inner_product import convert_innerproduct_to_pretty
 
 
 class LLMSymRegressor:
@@ -43,7 +44,8 @@ class LLMSymRegressor:
         bfgs_maxiter: int = 200,
         extra_prompt: str = "",
         exp_dir: Optional[str] = None,
-        save: bool = False,          
+        save: bool = False,
+        mode: str = 'base',          # NEW: 'base' or 'legacy'
         **kwargs
     ):
         self.llm_config = llm_config
@@ -56,13 +58,16 @@ class LLMSymRegressor:
         self.bfgs_maxiter = bfgs_maxiter
         self.extra_prompt = extra_prompt
         self.save = save
-        # 如果 save=False 且未指定 exp_dir，则不创建目录
+        self.mode = mode.lower()
+        if self.mode not in ('base', 'legacy'):
+            raise ValueError("mode must be 'base' or 'legacy'")
+
         if not save and exp_dir is None:
             self.exp_dir = None
         else:
             self.exp_dir = exp_dir or "./experiments"
         self._llm_client = None
-        self._database = None          # 用于保存 pipeline 返回的 database
+        self._database = None
 
         self.best_equation_: Optional[str] = None
         self.best_score_: float = -np.inf
@@ -72,9 +77,46 @@ class LLMSymRegressor:
         self._X_fitted = None
         self._y_fitted = None
 
+        self.neuron = None 
+
     def _build_specification(self) -> str:
         background_comment = f"# {self.background}" if self.background else ""
-        spec = f"""
+        if self.mode == 'base':
+            spec = f"""
+{background_comment}
+import numpy as np
+from scipy.optimize import minimize
+
+# 标量内积函数
+def IP(w, expr):
+    return w * np.sum(expr, axis=1)
+
+MAX_NPARAMS = {self.max_params}
+N_RESTARTS = {self.n_restarts}
+BFGS_MAXITER = {self.bfgs_maxiter}
+
+@equation.evolve
+def equation(x, params):
+    \"\"\"
+    Vectorized equation on full input matrix x (N×d).
+    x: 2D array (N, d)
+    params: 1D array of coefficients
+    Returns: (N,) predictions
+    \"\"\"
+    return IP(params[0], x)   # placeholder
+
+@evaluate.run
+def evaluate_run(data):
+    \"\"\"
+    data: dict with keys 'inputs' and 'outputs'
+    Returns: (score, result_data, best_params)
+    \"\"\"
+    inputs = data['inputs']
+    outputs = data['outputs']
+    return 0.0, np.zeros((inputs.shape[0], inputs.shape[1] + 2)), np.zeros(MAX_NPARAMS)
+"""
+        else:  # legacy
+            spec = f"""
 {background_comment}
 import numpy as np
 from scipy.optimize import minimize
@@ -108,21 +150,8 @@ def evaluate_run(data):
         return {'data': {'inputs': X, 'outputs': y}}
 
     def _get_best_from_database(self):
-        """从内存中的 database 获取最佳方程体（用于 save=False 时）"""
         if self._database is None:
             return None
-        # 遍历岛屿，找到最高分
-        best_score = -np.inf
-        best_body = None
-        for island in self._database._islands:
-            # 每个岛屿有 _best_program_per_island 和 _best_score_per_island
-            # 但我们无法直接访问，因为它们是私有属性，且 _best_program_per_island 可能为 None
-            # 更可靠：遍历所有 clusters
-            for sig, cluster in island._clusters.items():
-                # cluster 有 score 属性（平均分）和 _programs 列表
-                # 但 score 是注册时的分数，可能不是最新的。而 _best_program_per_island 是精确的。
-                pass
-        # 使用 _best_program_per_island
         best_idx = np.argmax(self._database._best_score_per_island)
         if self._database._best_score_per_island[best_idx] > -np.inf:
             return self._database._best_program_per_island[best_idx]
@@ -137,13 +166,13 @@ def evaluate_run(data):
         specification = self._build_specification()
         dataset = self._prepare_dataset(X, y)
 
-        # Build LLM client
         from .llm import ClientFactory
         if 'model' not in self.llm_config:
             raise ValueError("llm_config must contain 'model' in format 'provider/model'")
         client = ClientFactory.from_config(self.llm_config)
+        if hasattr(client, 'kwargs'):
+            client.kwargs['max_tokens'] = 2048
 
-        # Config
         buffer_config = config_lib.ExperienceBufferConfig(
             functions_per_prompt=3,
             num_islands=5,
@@ -165,14 +194,15 @@ def evaluate_run(data):
         )
 
         max_samples = self.max_iterations * self.samples_per_iteration
-        initial_body = "return params[0] * x"
+        if self.mode == 'base':
+            initial_body = "return IP(params[0], x)"
+        else:
+            initial_body = "return params[0] * x"
 
-        # 根据 save 决定是否创建目录和传递 log_dir
         log_dir = self.exp_dir if self.save else None
         if self.save and self.exp_dir:
             os.makedirs(self.exp_dir, exist_ok=True)
 
-        # Run pipeline, 获取返回的 database
         self._database = pipeline.main(
             specification=specification,
             inputs=dataset,
@@ -185,17 +215,14 @@ def evaluate_run(data):
             persist_all_samples=False,
             seed=None,
             extra_prompt=self.extra_prompt,
-            verbose=self.verbose > 0
-
+            verbose=self.verbose > 0,
+            mode=self.mode,          # pass mode to pipeline
         )
 
-        # 加载或提取最佳方程
         if self.save:
-            # 从文件加载（原有逻辑）
             samples_dir = os.path.join(self.exp_dir, 'samples')
             if not os.path.isdir(samples_dir):
                 raise RuntimeError("Samples directory not found; pipeline may have failed.")
-
             top_files = [f for f in os.listdir(samples_dir) if f.startswith('top') and f.endswith('.json')]
             if not top_files:
                 raise RuntimeError("No top files found; no equation discovered.")
@@ -212,7 +239,6 @@ def evaluate_run(data):
                     break
             if self.best_equation_ is None:
                 raise RuntimeError("Could not extract equation body from saved file.")
-            # Get score
             nmse = data.get('nmse')
             mse = data.get('mse')
             if nmse is not None:
@@ -222,14 +248,12 @@ def evaluate_run(data):
             else:
                 self.best_score_ = -np.inf
         else:
-            # 从内存 database 获取最佳体
             best_body = self._get_best_from_database()
             if best_body is None:
                 raise RuntimeError("No equation found in memory.")
             self.best_equation_ = best_body
-            # 分数我们无法从 database 直接获取，但可以重新评估（通过后续精炼会更新）
 
-        # Refine with high-precision BFGS (无论 save 与否都执行)
+        # Refine with high-precision BFGS
         temp_eval = evaluator.Evaluator(
             database=None,
             function_to_evolve='equation',
@@ -240,15 +264,20 @@ def evaluate_run(data):
             max_params=self.max_params,
             n_restarts=20,
             bfgs_maxiter=500,
-            complexity_penalty=0.0,  # no penalty for final refinement
+            complexity_penalty=0.0,
+            mode=self.mode,          # pass mode
         )
-        program = SINGLE_VAR_TEMPLATE.format(
+        if self.mode == 'base':
+            template = SINGLE_VAR_TEMPLATE_BASE
+        else:
+            template = SINGLE_VAR_TEMPLATE_LEGACY
+        program = template.format(
             max_params=self.max_params,
             n_restarts=20,
             bfgs_maxiter=500,
             equation_body=self.best_equation_
         )
-        sandbox = evaluator.LocalSandbox(verbose=self.verbose > 0)
+        sandbox = evaluator.LocalSandbox(verbose=self.verbose > 0, mode=self.mode)
         test_input = list(dataset.keys())[0]
         run_results = sandbox.run(
             program,
@@ -279,6 +308,7 @@ def evaluate_run(data):
                         return np.tile(pred[:, None], (1, self._y_fitted.shape[1]))
                     return pred
                 self.best_multivariate_func_ = multivariate_predict
+        self.neuron = self.get_neuron_formula()
 
         return self
 
@@ -299,11 +329,13 @@ def evaluate_run(data):
             for i, val in enumerate(self.best_params_):
                 expr = re.sub(rf'params\s*\[\s*{i}\s*\]', f'{val:.6f}', expr)
         expr = expr.replace('np.', 'torch.')
-        # Replace * with @ but keep **
+        # In base mode we have IP; in legacy we might have * which should become @
+        # But we'll apply general conversion:
         expr = re.sub(r'(?<!\*)\*(?!\*)', '@', expr)
-        # Fix torch.exp internal: replace @ with * inside exp
         expr = re.sub(r'(torch\.exp\s*\()([^)]*)\)',
                       lambda m: m.group(1) + re.sub(r'@', '*', m.group(2)) + ')', expr)
-        # Ensure coefficient before x: x @ coeff -> coeff @ x
         expr = re.sub(r'x\s*@\s*([\d.]+)', r'\1@x', expr)
-        return expr
+        if self.mode == 'base':
+            return convert_innerproduct_to_pretty(expr)
+        else:
+            return expr

--- a/tnlearn/drsr/buffer.py
+++ b/tnlearn/drsr/buffer.py
@@ -1,3 +1,4 @@
+# drsr/buffer.py
 # Copyright 2023 DeepMind Technologies Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +16,6 @@
 # This file is based on the DRSR project (https://github.com/scientific-intelligent-modelling/drsr)
 # and has been modified for vectorized symbolic regression.
 
-# drsr/buffer.py
 from __future__ import annotations
 
 import copy
@@ -89,6 +89,7 @@ class Island:
         functions_per_prompt: int,
         cluster_sampling_temperature_init: float,
         cluster_sampling_temperature_period: int,
+        mode: str = 'base',      # NEW
     ):
         self._functions_per_prompt = functions_per_prompt
         self._cluster_sampling_temperature_init = cluster_sampling_temperature_init
@@ -97,6 +98,7 @@ class Island:
         )
         self._clusters: dict[Signature, Cluster] = {}
         self._num_programs: int = 0
+        self._mode = mode
 
     def register_program(self, program: str, scores_per_test: ScoresPerTest) -> None:
         signature = _get_signature(scores_per_test)
@@ -110,12 +112,20 @@ class Island:
     def get_prompt(self) -> tuple[str, int]:
         signatures = list(self._clusters.keys())
         if not signatures:
-            return (
-                "def equation_v0(x, params):\n    return params[0] * x\n\n"
-                "def equation_v1(x, params):\n    return params[0]*x + params[1]*np.sin(x)\n\n"
-                "def equation_v2(x, params):\n    return params[0]*x**2 + params[1]\n\n"
-                "def equation_v3(x, params):\n    # write your return statement here\n", 3
-            )
+            if self._mode == 'base':
+                return (
+                    "def equation_v0(x, params):\n    return IP(params[0], x)\n\n"
+                    "def equation_v1(x, params):\n    return IP(params[0], x) + IP(params[1], x**2)\n\n"
+                    "def equation_v2(x, params):\n    return IP(params[0], x) * IP(params[1], x) + IP(params[2], x)\n\n"
+                    "def equation_v3(x, params):\n    # write your return statement here\n    # Example: IP(params[0], x) * IP(params[1], x) * IP(params[2], x) + IP(params[3], x)\n    return IP(params[0], x)", 3
+                )
+            else:  # legacy
+                return (
+                    "def equation_v0(x, params):\n    return params[0] * x\n\n"
+                    "def equation_v1(x, params):\n    return params[0]*x + params[1]*np.sin(x)\n\n"
+                    "def equation_v2(x, params):\n    return params[0]*x**2 + params[1]\n\n"
+                    "def equation_v3(x, params):\n    # write your return statement here\n", 3
+                )
 
         cluster_scores = np.array(
             [self._clusters[signature].score for signature in signatures]
@@ -160,8 +170,10 @@ class ExperienceBuffer:
     def __init__(
         self,
         config: config_lib.ExperienceBufferConfig,
+        mode: str = 'base',      # NEW
     ) -> None:
         self._config = config
+        self._mode = mode
         self._islands: list[Island] = []
         for _ in range(config.num_islands):
             self._islands.append(
@@ -169,6 +181,7 @@ class ExperienceBuffer:
                     config.functions_per_prompt,
                     config.cluster_sampling_temperature_init,
                     config.cluster_sampling_temperature_period,
+                    mode=mode,
                 )
             )
         self._best_score_per_island: list[float] = (
@@ -246,6 +259,7 @@ class ExperienceBuffer:
                 self._config.functions_per_prompt,
                 self._config.cluster_sampling_temperature_init,
                 self._config.cluster_sampling_temperature_period,
+                mode=self._mode,
             )
             self._best_score_per_island[island_id] = -float('inf')
             founder_island_id = np.random.choice(keep_islands_ids)

--- a/tnlearn/drsr/evaluator.py
+++ b/tnlearn/drsr/evaluator.py
@@ -1,3 +1,4 @@
+# drsr/evaluator.py
 # Copyright 2023 DeepMind Technologies Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +16,6 @@
 # This file is based on the DRSR project (https://github.com/scientific-intelligent-modelling/drsr)
 # and has been modified for vectorized symbolic regression.
 
-# drsr/evaluator.py
 from __future__ import annotations
 import time
 import multiprocessing
@@ -24,7 +24,7 @@ import re
 from typing import Any, Type, Optional, Dict
 from abc import abstractmethod, ABC
 
-from .template import SINGLE_VAR_TEMPLATE
+from .template import SINGLE_VAR_TEMPLATE_BASE, SINGLE_VAR_TEMPLATE_LEGACY
 from . import buffer
 
 
@@ -44,24 +44,25 @@ class Sandbox(ABC):
 
 
 class LocalSandbox(Sandbox):
-    def __init__(self, verbose=False, numba_accelerate=False, use_multiprocessing=None):
+    def __init__(self, verbose=False, numba_accelerate=False, use_multiprocessing=None, mode='base'):
         self._verbose = verbose
         self._numba_accelerate = numba_accelerate
-        # 自动检测：Windows上默认禁用多进程（因为spawn开销大且易出错），其他系统默认启用
+        # Auto-detect: disable multiprocessing on Windows to avoid spawn overhead and errors
         if use_multiprocessing is None:
             self._use_multiprocessing = (sys.platform != 'win32')
         else:
             self._use_multiprocessing = use_multiprocessing
+        self._mode = mode.lower()
 
     def run(self, program: str, function_to_run: str, function_to_evolve: str,
             inputs: Any, test_input: str, timeout_seconds: int, **kwargs):
         dataset = inputs[test_input]
         if self._use_multiprocessing:
-            # 使用多进程执行（用于Linux/macOS）
             result_queue = multiprocessing.Queue()
             process = multiprocessing.Process(
                 target=self._compile_and_run_function,
-                args=(program, function_to_run, function_to_evolve, dataset, self._numba_accelerate, result_queue, kwargs.get('seed', None))
+                args=(program, function_to_run, function_to_evolve, dataset,
+                      self._numba_accelerate, result_queue, kwargs.get('seed', None))
             )
             process.start()
             process.join(timeout=timeout_seconds)
@@ -75,7 +76,7 @@ class LocalSandbox(Sandbox):
                 self._print_evaluation_details(program, results, **kwargs)
             return results
         else:
-            # 直接执行（用于Windows或禁用多进程时）
+            # Direct execution (Windows or disabled multiprocessing)
             try:
                 all_globals_namespace = {}
                 exec(program, all_globals_namespace)
@@ -108,9 +109,10 @@ class LocalSandbox(Sandbox):
         return None, False
 
     def _print_evaluation_details(self, program, results, **kwargs):
-        print('================= Evaluated Program =================')
-        print(program[:200] + '...' if len(program) > 200 else program)
-        print(f'Score: {results}\n=====================================================\n\n')
+        if self._verbose >= 2:
+            print('================= Evaluated Program =================')
+            print(program[:200] + '...' if len(program) > 200 else program)
+            print(f'Score: {results}\n=====================================================\n\n')
 
     def _compile_and_run_function(self, program, function_to_run, function_to_evolve,
                                   dataset, numba_accelerate, result_queue, seed=None):
@@ -163,18 +165,22 @@ class Evaluator:
         bfgs_maxiter: int = 200,
         complexity_penalty: float = 0.01,
         verbose: bool = False,
+        mode: str = 'base',          # NEW: 'base' or 'legacy'
     ):
         self._database = database
         self._function_to_evolve = function_to_evolve
         self._function_to_run = function_to_run
         self._inputs = inputs
         self._timeout_seconds = timeout_seconds
-        self._sandbox = sandbox_class(verbose=verbose)
+        self._sandbox = sandbox_class(verbose=verbose, mode=mode)
         self._max_params = max_params
         self._n_restarts = n_restarts
         self._bfgs_maxiter = bfgs_maxiter
         self._complexity_penalty = complexity_penalty
         self._verbose = verbose
+        self._mode = mode.lower()
+        if self._mode not in ('base', 'legacy'):
+            raise ValueError("mode must be 'base' or 'legacy'")
 
     def analyse(
         self,
@@ -188,7 +194,13 @@ class Evaluator:
             print(f"Rejected sample due to params inside function argument: {sample[:100]}...")
             return
 
-        program = SINGLE_VAR_TEMPLATE.format(
+        # Choose template based on mode
+        if self._mode == 'base':
+            template = SINGLE_VAR_TEMPLATE_BASE
+        else:
+            template = SINGLE_VAR_TEMPLATE_LEGACY
+
+        program = template.format(
             max_params=self._max_params,
             n_restarts=self._n_restarts,
             bfgs_maxiter=self._bfgs_maxiter,
@@ -230,7 +242,7 @@ class Evaluator:
                 avg_score = sum(scores_per_test.values()) / len(scores_per_test)
                 if self._verbose:
                     print(f"[Evaluator] Body: {sample[:100]}... score={avg_score:.6f}")
-                    
+
             self._database.register_program(
                 sample,
                 island_id,

--- a/tnlearn/drsr/pipeline.py
+++ b/tnlearn/drsr/pipeline.py
@@ -1,3 +1,4 @@
+# drsr/pipeline.py
 # Copyright 2023 DeepMind Technologies Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +16,6 @@
 # This file is based on the DRSR project (https://github.com/scientific-intelligent-modelling/drsr)
 # and has been modified for vectorized symbolic regression.
 
-# drsr/pipeline.py
 from __future__ import annotations
 from typing import Any, Tuple, Sequence, Optional
 import numpy as np
@@ -44,16 +44,15 @@ def main(
     max_sample_nums: Optional[int],
     class_config: config_lib.ClassConfig,
     **kwargs
-) -> buffer.ExperienceBuffer:   # 返回 database
+) -> buffer.ExperienceBuffer:
     function_to_evolve, function_to_run = _extract_function_names(specification)
+    mode = kwargs.get('mode', 'base')   # NEW
 
-    # Create database
-    database = buffer.ExperienceBuffer(config.experience_buffer)
+    database = buffer.ExperienceBuffer(config.experience_buffer, mode=mode)
 
     extra_prompt = kwargs.get('extra_prompt', '')
     verbose = kwargs.get('verbose', False)
 
-    # Main evaluators
     evaluators = []
     for _ in range(config.num_evaluators):
         evaluators.append(evaluator.Evaluator(
@@ -65,9 +64,9 @@ def main(
             sandbox_class=class_config.sandbox_class,
             complexity_penalty=0.05,
             verbose=verbose,
+            mode=mode,
         ))
 
-    # Create profiler if log_dir provided
     log_dir = kwargs.get('log_dir')
     profiler = None
     if log_dir:
@@ -80,7 +79,6 @@ def main(
         )
         kwargs['profiler'] = profiler
 
-    # Initial evaluation
     initial_body = kwargs.get('initial_body', "return params[0] * x")
     print(f"Initial evaluation with body: {initial_body}")
     evaluators[0].analyse(
@@ -90,7 +88,6 @@ def main(
         **kwargs
     )
 
-    # Seed with nonlinear expressions (using high-precision evaluator)
     print("Seeding additional nonlinear expressions with high-precision BFGS...")
     seed_evaluator = evaluator.Evaluator(
         database,
@@ -104,10 +101,16 @@ def main(
         bfgs_maxiter=300,
         complexity_penalty=0.05,
         verbose=verbose,
+        mode=mode,
     )
-    seed_bodies = [
-        "return params[0]*x + params[1]*x**2",
-    ]
+    if mode == 'base':
+        seed_bodies = [
+            "return IP(params[0], x) + IP(params[1], x) * IP(params[2], x)",
+        ]
+    else:
+        seed_bodies = [
+            "return params[0]*x + params[1]*x**2",
+        ]
     for seed in seed_bodies:
         seed_evaluator.analyse(
             seed,
@@ -116,11 +119,9 @@ def main(
             **kwargs
         )
 
-    # Print database size for debugging
     total = sum(len(island._clusters) for island in database._islands)
     print(f"After initial evaluation and seeding, database has {total} clusters across islands.")
 
-    # Samplers
     samplers = [
         sampler.Sampler(
             database,
@@ -131,6 +132,7 @@ def main(
             llm_class=class_config.llm_class,
             llm_client=kwargs.get('llm_client'),
             extra_prompt=extra_prompt,
+            mode=mode,
         )
         for _ in range(config.num_samplers)
     ]
@@ -138,5 +140,4 @@ def main(
     for s in samplers:
         s.sample(**kwargs)
 
-    # 返回 database 以便调用方在内存中访问最佳个体
     return database

--- a/tnlearn/drsr/sampler.py
+++ b/tnlearn/drsr/sampler.py
@@ -1,3 +1,4 @@
+# drsr/sampler.py
 # Copyright 2023 DeepMind Technologies Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +16,6 @@
 # This file is based on the DRSR project (https://github.com/scientific-intelligent-modelling/drsr)
 # and has been modified for vectorized symbolic regression.
 
-# drsr/sampler.py (progressive stage-wise guidance)
 from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Collection, Sequence, Type, Optional, List
@@ -36,15 +36,19 @@ class LLM(ABC):
 
 
 class LocalLLM(LLM):
-    def __init__(self, samples_per_prompt: int, client=None, trim: bool = True) -> None:
+    def __init__(self, samples_per_prompt: int, client=None, trim: bool = True, mode: str = 'base') -> None:
         super().__init__(samples_per_prompt)
         self._client = client
         self._trim = trim
+        self._mode = mode
 
     def draw_samples(self, prompt: str, config: config_lib.Config, best_score: float = None, progress: float = 0.0, extra_prompt: str = "") -> Collection[str]:
         enhanced_prompt = self._build_enhanced_prompt(prompt, best_score, progress)
-        enhanced_prompt += "\n\nIMPORTANT: When using np.exp, np.sin, np.cos, etc., the argument must be only x or -x, etc. Do NOT put params inside the function argument. For example, use np.exp(x), np.sin(x), np.cos(x), NOT np.exp(params[0]*x)."
-        enhanced_prompt += "\nPrefer simpler expressions with fewer terms. A model with less than 3 terms is better than one with many terms if the performance is similar."
+        if self._mode == 'base':
+            enhanced_prompt += "\n\nIMPORTANT: When using np.exp, np.sin, np.cos, etc., the argument must be only x or -x, etc. Do NOT put params inside the function argument. For example, use np.exp(x), np.sin(x), np.cos(x), NOT np.exp(params[0]*x)."
+            enhanced_prompt += "\nPrefer simpler expressions with fewer terms. A model with less than 3 terms is better than one with many terms if the performance is similar."
+        else:
+            enhanced_prompt += "\n\nPrefer simpler expressions with fewer terms. A model with less than 3 terms is better than one with many terms if the performance is similar."
         if extra_prompt:
             enhanced_prompt += f"\n\n{extra_prompt}"
         return self._draw_samples_client(enhanced_prompt)
@@ -52,27 +56,40 @@ class LocalLLM(LLM):
     def _build_enhanced_prompt(self, prompt: str, best_score: float, progress: float) -> str:
         if best_score is None:
             return prompt
-        best_mse = -best_score  # score is negative MSE
+        best_mse = -best_score
 
-        # Stage-wise guidance (each prompt independent, no continuity hint)
-        if progress < 0.3:
-            # Early stage: guide only polynomials
-            if best_mse > 0.01:
-                hint = "\n\nHint: Try using higher-degree polynomial terms (x**k, k=2,3,4,5, etc.) to better capture curvature."
+        if self._mode == 'base':
+            if progress < 0.3:
+                if best_mse > 0.01:
+                    hint = "\n\nHint: Try using higher-degree polynomial terms (IP(params[i], x**k), k=2,3,4,5, etc.) to better capture curvature."
+                else:
+                    hint = "\n\nHint: Try polynomial forms with less than 3 terms. Keep it simple."
+            elif progress < 0.7:
+                if best_mse > 0.1:
+                    hint = "\n\nHint: Polynomial fit is poor. Try using cross term (IP(params[i], x)*IP(params[j], x)*...)."
+                else:
+                    hint = "\n\nHint: The current polynomial fit is decent. You may try slightly different combinations or add one more term if needed."
             else:
-                hint = "\n\nHint: Try polynomial forms with less than 3 terms. Keep it simple."
-        elif progress < 0.7:
-            # Middle stage: if fit is poor, suggest trigonometric/exponential; otherwise keep polynomial
-            if best_mse > 0.1:
-                hint = "\n\nHint: Polynomial fit is poor. Try using trigonometric (np.sin, np.cos) or exponential (np.exp) functions instead."
+                if best_mse > 0.1:
+                    hint = "\n\nHint: You can try any function type (polynomial, trig, exp, cross term) but keep the expression simple (≤3 terms)."
+                else:
+                    hint = "\n\nHint: The fit is already good. Focus on simplifying the expression (e.g., remove negligible terms)."
+        else:  # legacy
+            if progress < 0.3:
+                if best_mse > 0.01:
+                    hint = "\n\nHint: Try using higher-degree polynomial terms (x**k, k=2,3,4,5, etc.) to better capture curvature."
+                else:
+                    hint = "\n\nHint: Try polynomial forms with less than 3 terms. Keep it simple."
+            elif progress < 0.7:
+                if best_mse > 0.1:
+                    hint = "\n\nHint: Polynomial fit is poor. Try using trigonometric (np.sin, np.cos) or exponential (np.exp) functions instead."
+                else:
+                    hint = "\n\nHint: The current polynomial fit is decent. You may try slightly different combinations or add one more term if needed."
             else:
-                hint = "\n\nHint: The current polynomial fit is decent. You may try slightly different combinations or add one more term if needed."
-        else:
-            # Late stage: emphasize simplicity, allow all types but require conciseness
-            if best_mse > 0.1:
-                hint = "\n\nHint: You can try any function type (polynomial, trig, exp) but keep the expression simple (≤3 terms)."
-            else:
-                hint = "\n\nHint: The fit is already good. Focus on simplifying the expression (e.g., remove negligible terms)."
+                if best_mse > 0.1:
+                    hint = "\n\nHint: You can try any function type (polynomial, trig, exp) but keep the expression simple (≤3 terms)."
+                else:
+                    hint = "\n\nHint: The fit is already good. Focus on simplifying the expression (e.g., remove negligible terms)."
         return prompt + hint
 
     def _draw_samples_client(self, prompt: str) -> List[str]:
@@ -85,24 +102,42 @@ class LocalLLM(LLM):
                 result = self._client.chat(messages)
                 content = result.get('content', '')
                 body = None
-                for line in content.splitlines():
+                lines = content.splitlines()
+                for i, line in enumerate(lines):
                     stripped = line.strip()
                     if stripped.startswith('return '):
-                        body = stripped
+                        rest = stripped[6:].lstrip()
+                        if rest.startswith('('):
+                            body_lines = [line]
+                            open_parens = line.count('(') - line.count(')')
+                            j = i + 1
+                            while j < len(lines) and open_parens > 0:
+                                next_line = lines[j]
+                                body_lines.append(next_line)
+                                open_parens += next_line.count('(') - next_line.count(')')
+                                j += 1
+                            body = '\n'.join(body_lines).strip()
+                        else:
+                            body = stripped
                         break
                 if body is None:
-                    body = "return x * params[0]"
+                    if self._mode == 'base':
+                        body = "return IP(params[0], x)"
+                    else:
+                        body = "return x * params[0]"
                 all_samples.append(body)
             except Exception as e:
-                # check if the error message contains keywords indicating an authentication issue
                 error_str = str(e).lower()
                 if any(keyword in error_str for keyword in ['auth', 'api key', 'credential', '401', '403', 'permission']):
                     print(f"Authentication error: {e}")
                     print("Please check your LLM API key configuration.")
-                    raise  # raise exception to stop sampling if authentication fails
+                    raise
                 else:
                     print(f"LLM error: {e}")
-                    all_samples.append("return x * params[0]")
+                    if self._mode == 'base':
+                        all_samples.append("return IP(params[0], x)")
+                    else:
+                        all_samples.append("return x * params[0]")
         return all_samples
 
 
@@ -119,14 +154,15 @@ class Sampler:
         llm_class: Type[LLM] = LocalLLM,
         llm_client=None,
         extra_prompt: str = "",
+        mode: str = 'base',      # NEW
     ):
         self._samples_per_prompt = samples_per_prompt
         self._database = database
         self._evaluators = evaluators
-        self._llm = llm_class(samples_per_prompt, client=llm_client)
+        self._llm = llm_class(samples_per_prompt, client=llm_client, mode=mode)
         self._max_sample_nums = max_sample_nums
         self.config = config
-        self._extra_prompt = extra_prompt 
+        self._extra_prompt = extra_prompt
 
     def sample(self, **kwargs):
         start_time = time.time()
@@ -139,16 +175,14 @@ class Sampler:
                 break
 
             prompt = self._database.get_prompt()
-            # Calculate search progress
             if self._max_sample_nums:
                 progress = min(1.0, self.__class__._global_samples_nums / self._max_sample_nums)
             else:
-                progress = 0.0  # Default to early stage when no upper limit
+                progress = 0.0
             best_score = max(self._database._best_score_per_island) if self._database._best_score_per_island else None
             reset_time = time.time()
             samples = self._llm.draw_samples(prompt.code, self.config, best_score=best_score, progress=progress, extra_prompt=self._extra_prompt)
 
-            # ----- New deduplication logic -----
             unique_samples = []
             seen = set()
             for s in samples:
@@ -158,7 +192,6 @@ class Sampler:
             if len(unique_samples) < len(samples):
                 print(f"[Sampler] Deduplicated: {len(samples)} -> {len(unique_samples)}")
             samples = unique_samples
-            # ------------------------------------
 
             sample_time = (time.time() - reset_time) / self._samples_per_prompt
 

--- a/tnlearn/drsr/template.py
+++ b/tnlearn/drsr/template.py
@@ -1,3 +1,4 @@
+# drsr/template.py
 # Copyright 2023 DeepMind Technologies Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,8 +16,75 @@
 # This file is based on the DRSR project (https://github.com/scientific-intelligent-modelling/drsr)
 # and has been modified for vectorized symbolic regression.
 
-# drsr/template.py
-SINGLE_VAR_TEMPLATE = '''
+SINGLE_VAR_TEMPLATE_BASE = '''
+import numpy as np
+from scipy.optimize import minimize
+
+MAX_NPARAMS = {max_params}
+N_RESTARTS = {n_restarts}
+BFGS_MAXITER = {bfgs_maxiter}
+
+# 标量内积函数：权重 w（标量）与矩阵 expr（N×d）的内积，返回 (N,)
+def IP(w, expr):
+    return w * np.sum(expr, axis=1)
+
+def equation(x, params):
+    """
+    Vectorized equation on full input matrix x (N×d).
+    x: 2D array (N, d)
+    params: 1D array of coefficients
+    Returns: (N,) predictions
+    """
+    {equation_body}
+
+def evaluate_run(data):
+    inputs = data['inputs']   # (N, d)
+    outputs = data['outputs'] # (N,)
+
+    def loss(params):
+        y_pred = equation(inputs, params)
+        if outputs.ndim == 2 and outputs.shape[1] > 1:
+            y_pred_expanded = np.tile(y_pred[:, None], (1, outputs.shape[1]))
+        else:
+            y_pred_expanded = y_pred
+        return np.mean((y_pred_expanded - outputs) ** 2)
+
+    best_loss = np.inf
+    best_params = None
+    for _ in range(N_RESTARTS):
+        x0 = np.random.uniform(-1, 1, size=MAX_NPARAMS)
+        try:
+            res = minimize(loss, x0, method='BFGS',
+                          options={{'maxiter': BFGS_MAXITER, 'disp': False}})
+            if res.fun < best_loss:
+                best_loss = res.fun
+                best_params = res.x
+        except:
+            continue
+
+    if best_params is None:
+        return -np.inf, None, None
+
+    y_pred = equation(inputs, best_params)
+    if outputs.ndim == 2 and outputs.shape[1] > 1:
+        y_pred_expanded = np.tile(y_pred[:, None], (1, outputs.shape[1]))
+        residuals = outputs - y_pred_expanded
+    else:
+        residuals = outputs - y_pred
+    var_y = np.var(outputs)
+    nmse = best_loss / var_y if var_y > 0 else np.inf
+
+    if outputs.ndim == 1:
+        outputs_2d = outputs[:, None]
+        residuals_2d = residuals[:, None]
+    else:
+        outputs_2d = outputs
+        residuals_2d = residuals
+    result_data = np.column_stack((inputs, outputs_2d, residuals_2d))
+    return -nmse, result_data, best_params
+'''
+
+SINGLE_VAR_TEMPLATE_LEGACY = '''
 import numpy as np
 from scipy.optimize import minimize
 

--- a/tnlearn/gp_regressor.py
+++ b/tnlearn/gp_regressor.py
@@ -1,0 +1,691 @@
+"""
+Genetic Programming Symbolic Regressors.
+
+This module provides two symbolic regression implementations:
+1. VecSymRegressor (legacy): Original vectorized symbolic regression.
+2. GPSymRegressor (new): Enhanced GP with InnerProduct, advanced functions, and mode selection.
+
+Copyright (c) 2024 Meng WANG. All Rights Reserved.
+Copyright (c) 2026 Tieyun LI. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import numpy as np
+from sympy import sympify, expand
+import operator
+from random import randint, random, shuffle, seed
+from copy import deepcopy
+from tqdm import tqdm
+import re
+
+# InnerProduct support for GPSymRegressor (advanced/base modes)
+from .operator.inner_product import InnerProduct, inner_product, convert_pretty_to_innerproduct, _simplify_expr
+
+
+# ---------- Helper for random seed ----------
+def _set_random_state(rs):
+    """Set random seed for both random and numpy."""
+    seed(rs)
+    np.random.seed(rs)
+
+
+# =============================================================================
+# GPSymRegressor
+# =============================================================================
+class GPSymRegressor:
+    """
+    Genetic Programming Symbolic Regressor with InnerProduct and advanced modes.
+    Supports 'base' (basic ops), 'advanced' (trig, exp, log, power), and 'legacy'
+    (which delegates to VecSymRegressor).
+
+    Parent selection strategies:
+        - 'rank' (default): Rank-based weighted roulette (higher rank = higher chance).
+        - 'tournament': Tournament selection using `tournament_size`.
+    """
+
+    def __init__(self,
+                 random_state=100,
+                 pop_size=5000,
+                 max_generations=20,
+                 tournament_size=10,
+                 coefficient_range=None,
+                 x_pct=0.7,
+                 xover_pct=0.3,
+                 save=False,
+                 operations=None,
+                 max_depth=6,
+                 complexity_penalty=0.0,
+                 node_penalty_coef=0.001,
+                 immigration_rate=0.1,
+                 elite_ratio=0.1,
+                 mode='base',
+                 maxpower=5,
+                 parent_selection='rank', 
+                 debug=False):
+        """
+        Args:
+            random_state (int): Seed.
+            pop_size (int): Population size.
+            max_generations (int): Generations.
+            tournament_size (int): Tournament size (used when parent_selection='tournament').
+            coefficient_range (list): Range for random constants.
+            x_pct (float): Probability of variable leaf.
+            xover_pct (float): Crossover probability.
+            save (bool): Save log.
+            operations (tuple): Custom operations (overrides default).
+            max_depth (int): Maximum tree depth.
+            complexity_penalty (float): Penalty per InnerProduct.
+            node_penalty_coef (float): Penalty per node.
+            immigration_rate (float): Rate of random immigrant.
+            elite_ratio (float): Fraction of elites kept.
+            mode (str): 'base', 'advanced', or 'legacy'.
+            maxpower (int): Max exponent magnitude for power operator.
+            parent_selection (str): Parent selection strategy: 'rank' or 'tournament'.
+            debug (bool): Print debug info.
+        """
+        _set_random_state(random_state)
+        self.random_state = random_state
+        self.pop_size = pop_size
+        self.max_generations = max_generations
+        self.tournament_size = tournament_size
+
+        self.x_pct = x_pct
+        self.xover_pct = xover_pct
+        self.save = save
+        self.max_depth = max_depth
+        self.complexity_penalty = complexity_penalty
+        self.node_penalty_coef = node_penalty_coef
+        self.immigration_rate = immigration_rate
+        self.elite_ratio = elite_ratio
+        self.debug = debug
+
+        self.global_best = float("inf")
+        self.best_prog = None
+        self.neuron = None
+
+        # Parent selection strategy
+        self.parent_selection = parent_selection
+        if self.parent_selection not in ('rank', 'tournament'):
+            raise ValueError("parent_selection must be 'rank' or 'tournament'")
+        # Ensure tournament_size has a sensible default if not provided
+        if self.parent_selection == 'tournament' and self.tournament_size is None:
+            self.tournament_size = 10
+
+        if coefficient_range is None:
+            self.coefficient_range = [-1, 1]
+        else:
+            self.coefficient_range = coefficient_range
+
+        self.mode = mode
+        self.maxpower = maxpower
+
+        # For legacy mode, we skip operation initialization
+        if mode == 'legacy':
+            self.operations = None
+            self.power_prob = 0.0
+            # We won't use these but set to avoid attribute errors
+            self._simp_cache = {}
+            return
+
+        # Default operations (base)
+        base_ops = (
+            {"func": operator.add, "arg_count": 2, "format_str": "({} + {})"},
+            {"func": operator.sub, "arg_count": 2, "format_str": "({} - {})"},
+            {"func": operator.mul, "arg_count": 2, "format_str": "({} * {})"},
+            {"func": operator.neg, "arg_count": 1, "format_str": "-({})"},
+            {"func": lambda a, b: InnerProduct(a, b), "arg_count": 2,
+             "format_str": "InnerProduct({}, {})"},
+        )
+
+        if mode == 'base':
+            if operations is not None:
+                self.operations = operations
+            else:
+                self.operations = base_ops
+            self.power_prob = 0.0
+        elif mode == 'advanced':
+            advanced_ops = (
+                {"func": np.sin, "arg_count": 1, "format_str": "sin({})"},
+                {"func": np.cos, "arg_count": 1, "format_str": "cos({})"},
+                {"func": np.exp, "arg_count": 1, "format_str": "exp({})"},
+                {"func": np.log, "arg_count": 1, "format_str": "log({})"},
+                {"func": np.tan, "arg_count": 1, "format_str": "tan({})"},
+            )
+            if operations is not None:
+                self.operations = operations
+            else:
+                self.operations = base_ops + advanced_ops
+            self.power_prob = 1.0 / (len(self.operations) + 1)
+        else:
+            raise ValueError("mode must be 'base', 'advanced', or 'legacy'")
+
+        self._simp_cache = {}
+
+    def render_prog(self, node):
+        if "children" not in node:
+            return node["feature_name"]
+        return node["format_str"].format(*[self.render_prog(c) for c in node["children"]])
+
+    def get_tree_depth(self, node):
+        if "children" not in node:
+            return 1
+        return 1 + max([self.get_tree_depth(c) for c in node["children"]])
+
+    def simp(self, tree):
+        key = self.render_prog(tree)
+        if key in self._simp_cache:
+            return self._simp_cache[key]
+        expr_str = key
+        try:
+            sym_expr = sympify(expr_str, locals={'InnerProduct': InnerProduct})
+            sym_expr = expand(sym_expr)
+            sym_expr = _simplify_expr(sym_expr)
+            result = str(sym_expr)
+        except Exception:
+            result = expr_str
+            if self.debug:
+                print(f"[WARNING] Simplification failed for: {expr_str}")
+        self._simp_cache[key] = result
+        return result
+
+    def evaluate(self, expr_str, x_data):
+        N = x_data.shape[0]
+        def batch_inner(a, b):
+            return inner_product(a, b, N=N)
+        safe_dict = {
+            'x': x_data,
+            'InnerProduct': batch_inner,
+            'np': np,
+            'sin': np.sin,
+            'cos': np.cos,
+            'exp': np.exp,
+            'sqrt': np.sqrt,
+            'log': np.log,
+            'tan': np.tan
+        }
+        pred = eval(expr_str, safe_dict)
+        return expr_str, pred
+
+    def compute_fitness(self, expr_str, pred, label, node_count):
+        if expr_str.count('x') <= 1:
+            return float("inf")
+        if 'x' not in expr_str:
+            return float("inf")
+        if expr_str.strip() in ('x', '1', '-1'):
+            return float("inf")
+
+        if pred.ndim == 2:
+            if pred.shape[1] == 1:
+                pred = pred.flatten()
+            else:
+                pred = np.sum(pred, axis=1)
+        elif pred.ndim != 1:
+            return float("inf")
+
+        if len(pred) != len(label):
+            return float("inf")
+
+        mse = np.mean(np.square(pred - label))
+
+        if self.complexity_penalty > 0:
+            ip_count = expr_str.count('InnerProduct')
+            mse += self.complexity_penalty * ip_count
+
+        if self.node_penalty_coef > 0:
+            mse += self.node_penalty_coef * node_count
+
+        return mse
+
+    def rand_w(self):
+        low, high = self.coefficient_range
+        eps = 1e-4
+        if low < 0 < high:
+            if random() < 0.5:
+                val = np.random.uniform(low, -eps)
+            else:
+                val = np.random.uniform(eps, high)
+        else:
+            val = np.random.uniform(low, high)
+        return str(val)
+
+    def _rand_power(self):
+        low = -self.maxpower
+        high = self.maxpower
+        eps = 1e-4
+        if low < 0 < high:
+            if random() < 0.5:
+                val = np.random.uniform(low, -eps)
+            else:
+                val = np.random.uniform(eps, high)
+        else:
+            val = np.random.uniform(low, high)
+        return str(val)
+
+    def random_prog(self, depth=0, max_depth=None):
+        if max_depth is None:
+            max_depth = self.max_depth
+
+        if self.mode == 'advanced' and depth < max_depth:
+            if random() < self.power_prob:
+                child = self.random_prog(depth + 1, max_depth)
+                power = self._rand_power()
+                power_leaf = {"feature_name": power}
+                return {
+                    "func": operator.pow,
+                    "children": [child, power_leaf],
+                    "format_str": "({} ** {})",
+                }
+
+        if depth >= max_depth:
+            return {'feature_name': 'x'} if random() < self.x_pct else {'feature_name': self.rand_w()}
+        op = self.operations[randint(0, len(self.operations) - 1)]
+        return {
+            "func": op["func"],
+            "children": [self.random_prog(depth + 1, max_depth) for _ in range(op["arg_count"])],
+            "format_str": op["format_str"],
+        }
+
+    def select_random_node(self, selected, parent, depth):
+        if "children" not in selected:
+            return parent
+        if randint(0, 10) < 2 * depth:
+            return selected
+        child_count = len(selected["children"])
+        return self.select_random_node(
+            selected["children"][randint(0, child_count - 1)],
+            selected, depth + 1)
+
+    def do_mutate(self, selected):
+        for attempt in range(10):
+            offspring = deepcopy(selected)
+            mutate_point = self.select_random_node(offspring, None, 0)
+            child_count = len(mutate_point["children"])
+            mutate_point["children"][randint(0, child_count - 1)] = self.random_prog(0, max_depth=2)
+            if self.get_tree_depth(offspring) <= self.max_depth:
+                return offspring
+        return self.random_prog(0)
+
+    def do_xover(self, selected1, selected2):
+        for attempt in range(10):
+            offspring = deepcopy(selected1)
+            xover_point1 = self.select_random_node(offspring, None, 0)
+            xover_point2 = self.select_random_node(selected2, None, 0)
+            child_count = len(xover_point1["children"])
+            xover_point1["children"][randint(0, child_count - 1)] = xover_point2
+            if self.get_tree_depth(offspring) <= self.max_depth:
+                return offspring
+        return self.random_prog(0)
+
+    def get_random_parent(self, popu, fitne):
+        """
+        Select a parent based on the chosen parent_selection strategy.
+        """
+        # ---------- Tournament selection ----------
+        if self.parent_selection == 'tournament':
+            k = self.tournament_size if self.tournament_size else 10
+            N = len(popu)
+            if k > N:
+                k = N
+            indices = np.random.choice(N, size=k, replace=False)
+            best_idx = min(indices, key=lambda i: fitne[i])
+            return popu[best_idx]
+
+        # ---------- Rank‑based weighted selection (default) ----------
+        else:  # 'rank'
+            sorted_indices = np.argsort(fitne)
+            N = len(fitne)
+            weights = np.arange(N, 0, -1)
+            total = weights.sum()
+            probs = weights / total
+            idx = np.random.choice(sorted_indices, p=probs)
+            return popu[idx]
+
+    def get_offspring(self, popula, ftns):
+        if random() < self.immigration_rate:
+            return self.random_prog(0)
+        tempt = random()
+        parent1 = self.get_random_parent(popula, ftns)
+        if tempt < self.xover_pct:
+            parent2 = self.get_random_parent(popula, ftns)
+            return self.do_xover(parent1, parent2)
+        elif self.xover_pct <= tempt < 0.9:
+            return self.do_mutate(parent1)
+        else:
+            return parent1
+
+    def node_count(self, x):
+        if "children" not in x:
+            return 1
+        return sum([self.node_count(c) for c in x["children"]])
+
+    def _format_pretty(self, expr_str):
+        def repl(match):
+            args = match.group(1)
+            parts = args.split(',', 1)
+            if len(parts) == 2:
+                return f"<{parts[0].strip()}, {parts[1].strip()}>"
+            return match.group(0)
+        while True:
+            new_expr = re.sub(r'InnerProduct\(([^()]*)\)', repl, expr_str)
+            if new_expr == expr_str:
+                break
+            expr_str = new_expr
+        return expr_str
+
+    def fit(self, X, y):
+        """Fit the regressor to data."""
+        _set_random_state(self.random_state)
+        if X.ndim == 1:
+            X = X.reshape(-1, 1)
+
+        # ----- Legacy mode: delegate to VecSymRegressor -----
+        if self.mode == 'legacy':
+            vec_reg = VecSymRegressor(
+                random_state=self.random_state,
+                pop_size=self.pop_size,
+                max_generations=self.max_generations,
+                tournament_size=self.tournament_size,
+                coefficient_range=self.coefficient_range,
+                x_pct=self.x_pct,
+                xover_pct=self.xover_pct,
+                save=self.save,
+                operations=None   # use default ops
+            )
+            vec_reg.fit(X, y)
+            # Copy results
+            self.best_score = vec_reg.best_score
+            self.best_program = vec_reg.best_program
+            self.neuron = vec_reg.neuron
+            self.global_best = self.best_score
+            self.best_prog = self.best_program
+            return self
+
+        # ----- Base / Advanced modes -----
+        self._simp_cache = {}
+        self.population = [self.random_prog() for _ in range(self.pop_size)]
+        self.box = {}
+
+        if self.save:
+            file = open("log.txt", 'w')
+
+        for gen in tqdm(range(self.max_generations), desc="Fitting Progress"):
+            fitness = []
+            for prog in self.population:
+                expr_str = self.simp(prog)
+                if self.mode == 'advanced':
+                    if any(bad in expr_str for bad in ('I', 'zoo', 'nan', 'inf', 'E')):
+                        fitness.append(float("inf"))
+                        continue
+                try:
+                    _, prediction = self.evaluate(expr_str, X)
+                except Exception:
+                    fitness.append(float("inf"))
+                    continue
+                n_nodes = self.node_count(prog)
+                score = self.compute_fitness(expr_str, prediction, y, n_nodes)
+                fitness.append(score)
+
+                if score < self.global_best:
+                    self.global_best = score
+                    self.best_prog = expr_str
+
+                if len(self.box) < self.pop_size * 0.05:
+                    self.box[score] = prog
+                else:
+                    key_sort = sorted(self.box)
+                    if score < key_sort[-1]:
+                        self.box.pop(key_sort[-1])
+                        self.box[score] = prog
+
+            if self.debug:
+                finite_count = sum(np.isfinite(fitness))
+                print(f"\n[DEBUG] Generation {gen+1}/{self.max_generations}")
+                print(f"  Best fitness: {self.global_best:.6f}")
+                print(f"  Best expression: {self.best_prog}")
+                if fitness:
+                    median = np.median(fitness)
+                    mean = np.mean(fitness)
+                    inf_count = sum(np.isinf(fitness))
+                    print(f"  Pop median fitness: {median:.6f}, mean: {mean:.6f}, inf count: {inf_count}")
+                    print(f"  Finite fitness count: {finite_count} / {len(fitness)}")
+
+            if self.save:
+                file.write(
+                    "Generation: {:d}\nBest Score: {:.4f}\nMedian score: {:.4f}\nBest program: {:s}\n\n"
+                    .format(gen+1, self.global_best, np.median(np.array(fitness)), str(self.best_prog))
+                )
+
+            elite_limit = max(1, int(self.pop_size * self.elite_ratio))
+            sorted_elites = sorted(self.box.items(), key=lambda x: x[0])[:elite_limit]
+            elites = [prog for _, prog in sorted_elites]
+
+            num_offspring = self.pop_size - len(elites)
+            if num_offspring > 0:
+                shuffle(self.population)
+                offspring = [self.get_offspring(self.population, fitness) for _ in range(num_offspring)]
+            else:
+                offspring = []
+
+            self.population = (offspring + elites)[:self.pop_size]
+
+        self.best_score = self.global_best
+        self.best_program = self.best_prog
+        if self.save:
+            file.write("Best score: %f\n" % self.best_score)
+            file.write("Best program: %s\n" % str(self.best_prog))
+            file.close()
+
+        self.neuron = self._format_pretty(self.best_prog) if self.best_prog else None
+        return self
+
+
+# =============================================================================
+# VecSymRegressor (Legacy)
+# =============================================================================
+class VecSymRegressor:
+    """
+    Legacy vectorized symbolic regression.
+
+    Original implementation by Meng WANG.
+    """
+
+    def __init__(self,
+                 random_state=100,
+                 pop_size=5000,
+                 max_generations=20,
+                 tournament_size=10,
+                 coefficient_range=None,
+                 x_pct=0.7,
+                 xover_pct=0.3,
+                 save=False,
+                 operations=None):
+        """
+        Args:
+            random_state (int): Seed for random number generation.
+            pop_size (int): Population size.
+            max_generations (int): Maximum generations.
+            tournament_size (int): Size of tournament selection.
+            coefficient_range (list): Range for random constants.
+            x_pct (float): Probability of selecting a variable node.
+            xover_pct (float): Crossover probability.
+            save (bool): Whether to save log.
+            operations (tuple): Custom operations (default uses +, -, *, neg).
+        """
+        _set_random_state(random_state)
+        self.random_state = random_state
+        self.pop_size = pop_size
+        self.max_generations = max_generations
+        self.tournament_size = tournament_size or round(pop_size * 0.03)
+
+        self.x_pct = x_pct
+        self.xover_pct = xover_pct
+        self.save = save
+
+        self.global_best = float("inf")
+        self.best_prog = None
+        self.neuron = None
+
+        if coefficient_range is None:
+            self.coefficient_range = [-1, 1]
+        else:
+            self.coefficient_range = coefficient_range
+
+        self.operations = operations or (
+            {"func": operator.add, "arg_count": 2, "format_str": "({} + {})"},
+            {"func": operator.sub, "arg_count": 2, "format_str": "({} - {})"},
+            {"func": operator.mul, "arg_count": 2, "format_str": "({} * {})"},
+            {"func": operator.neg, "arg_count": 1, "format_str": "-({})"},
+        )
+
+    def render_prog(self, node):
+        if "children" not in node:
+            return node["feature_name"]
+        return node["format_str"].format(*[self.render_prog(c) for c in node["children"]])
+
+    def simp(self, tree):
+        return str(expand(sympify(self.render_prog(tree)))).replace("*", "@").replace('@@', '**')
+
+    def evaluate(self, expr, x_data):
+        x = x_data
+        temp = re.split(' ', expr)
+        for n, i_exp in enumerate(temp):
+            if '@' in i_exp:
+                index = i_exp.find('@')
+                tem = list(i_exp)
+                tem[index - 1] = str((eval(''.join(i_exp[0:index])) * np.ones((1, x_data.shape[0]))).tolist())
+                del tem[0:index - 1]
+                temp[n] = ''.join(tem)
+        ex = ''.join(temp)
+        return expr, eval(ex)
+
+    def rand_w(self):
+        return str(np.random.randint(low=self.coefficient_range[0], high=self.coefficient_range[1]))
+
+    def random_prog(self, depth=0):
+        n_d = depth
+        op = self.operations[randint(0, len(self.operations) - 1)]
+        if randint(0, 10) >= depth and n_d <= 6:
+            n_d += 1
+            return {
+                "func": op["func"],
+                "children": [self.random_prog(depth + 1) for _ in range(op["arg_count"])],
+                "format_str": op["format_str"],
+            }
+        else:
+            return {"feature_name": 'x'} if random() < self.x_pct else {"feature_name": self.rand_w()}
+
+    def select_random_node(self, selected, parent, depth):
+        if "children" not in selected:
+            return parent
+        if randint(0, 10) < 2 * depth:
+            return selected
+        child_count = len(selected["children"])
+        return self.select_random_node(
+            selected["children"][randint(0, child_count - 1)],
+            selected, depth + 1)
+
+    def do_mutate(self, selected):
+        offspring = deepcopy(selected)
+        mutate_point = self.select_random_node(offspring, None, 0)
+        child_count = len(mutate_point["children"])
+        mutate_point["children"][randint(0, child_count - 1)] = self.random_prog(0)
+        return offspring
+
+    def do_xover(self, selected1, selected2):
+        offspring = deepcopy(selected1)
+        xover_point1 = self.select_random_node(offspring, None, 0)
+        xover_point2 = self.select_random_node(selected2, None, 0)
+        child_count = len(xover_point1["children"])
+        xover_point1["children"][randint(0, child_count - 1)] = xover_point2
+        return offspring
+
+    def get_random_parent(self, popu, fitne):
+        tournament_members = [
+            randint(0, self.pop_size - 1) for _ in range(self.tournament_size)]
+        member_fitness = [(fitne[i], popu[i]) for i in tournament_members]
+        return min(member_fitness, key=lambda x: x[0])[1]
+
+    def get_offspring(self, popula, ftns):
+        tempt = random()
+        parent1 = self.get_random_parent(popula, ftns)
+        if tempt < self.xover_pct:
+            parent2 = self.get_random_parent(popula, ftns)
+            return self.do_xover(parent1, parent2)
+        elif self.xover_pct <= tempt < 0.9:
+            return self.do_mutate(parent1)
+        else:
+            return parent1
+
+    def node_count(self, x):
+        if "children" not in x:
+            return 1
+        return sum([self.node_count(c) for c in x["children"]])
+
+    def compute_fitness(self, func, pred, label):
+        m = func.count('x')
+        if m == 0 or m == 1:
+            return float("inf")
+        else:
+            mse = np.mean(np.square(pred - label))
+            return mse
+
+    def fit(self, X, y):
+        X = X.T
+        y = y.T
+        self.population = [self.random_prog() for _ in range(self.pop_size)]
+        self.box = {}
+
+        if self.save:
+            file = open("log.txt", 'w')
+
+        for gen in tqdm(range(self.max_generations), desc="Fitting Progress"):
+            fitness = []
+            for prog in self.population:
+                func, prediction = self.evaluate(self.simp(prog), X)
+                score = self.compute_fitness(func, prediction, y)
+                fitness.append(score)
+
+                if score < self.global_best:
+                    self.global_best = score
+                    self.best_prog = func
+
+                if len(self.box) < self.pop_size * 0.05:
+                    self.box[score] = prog
+                else:
+                    key_sort = sorted(self.box)
+                    if score < key_sort[-1]:
+                        self.box.pop(key_sort[-1])
+                        self.box[score] = prog
+
+            if self.save:
+                file.write(
+                    "Generation: {:d}\nBest Score: {:.4f}\nMedian score: {:.4f}\nBest program: {:s}\n\n"
+                    .format(gen+1, self.global_best, np.median(np.array(fitness)), str(self.best_prog))
+                )
+
+            lst = list(self.box.values())
+            self.population += lst
+            shuffle(self.population)
+            population_new = [self.get_offspring(self.population, fitness) for _ in range(self.pop_size)]
+            self.population = population_new + lst
+
+        self.best_score = self.global_best
+        self.best_program = self.best_prog
+
+        if self.save:
+            file.write("Best score: %f\n" % self.best_score)
+            file.write("Best program: %s\n" % self.best_program)
+            file.close()
+
+        self.neuron = self.best_program

--- a/tnlearn/mlpclassifier.py
+++ b/tnlearn/mlpclassifier.py
@@ -1,33 +1,152 @@
-# Copyright 2024 Meng WANG. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# ==============================================================================
+"""
+MLPClassifier with customizable neuron layers.
 
+This module provides two versions of CustomNeuronLayer:
+- BaseCustomNeuronLayer (default): uses SymPy parameterization with InnerProduct.
+- LegacyCustomNeuronLayer: imported from tnlearn.neurons (original implementation).
+
+Copyright (c) 2024 Meng WANG. All Rights Reserved.
+Copyright (c) 2026 Tieyun LI. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import math
 import torch
-from torch import nn
-from torch.utils.data import DataLoader, TensorDataset
+import torch.nn as nn
+from torch.nn.parameter import Parameter
+from torch.nn import init
+import sympy as sp
+from sympy import symbols, Add, Mul, Pow, sin, cos, exp, simplify, expand, sympify, Symbol, Number
 import numpy as np
 import torch.optim.lr_scheduler as lr_scheduler
-from tnlearn.neurons import CustomNeuronLayer
+from torch.utils.data import DataLoader, TensorDataset
+from torchinfo import summary
+from sklearn.metrics import accuracy_score
+
 from tnlearn.seeds import random_seed
 from tnlearn.activation_function import get_activation_function
 from tnlearn.loss_function import get_loss_function
 from tnlearn.optimizer import get_optimizer
 from tnlearn.base import BaseModel
-from torchinfo import summary
-from sklearn.metrics import accuracy_score
+
+# Import legacy CustomNeuronLayer from original package
+from tnlearn.neurons import CustomNeuronLayer as LegacyCustomNeuronLayer
+
+# Import InnerProduct utilities for base mode
+from tnlearn.operator.inner_product import (
+    InnerProduct,
+    convert_pretty_to_innerproduct,
+    parameterize_expression,
+    evaluate_expression,
+)
 
 
+# ---------- Base CustomNeuronLayer (new version) ----------
+class BaseCustomNeuronLayer(nn.Module):
+    """
+    Custom neuron layer using SymPy parameterization with InnerProduct.
+    """
+    def __init__(self, in_features: int, out_features: int, symbolic_expression: str, bias: bool = True):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.raw_expr = symbolic_expression
+
+        # 1. Convert to InnerProduct format
+        expr_str = convert_pretty_to_innerproduct(symbolic_expression)
+        local_dict = {'InnerProduct': InnerProduct}
+        try:
+            sym_expr = sympify(expr_str, locals=local_dict)
+        except Exception as e:
+            raise ValueError(f"Failed to parse expression: {expr_str}\nError: {e}")
+
+        # Expand and simplify
+        sym_expr = expand(sym_expr)
+        sym_expr = simplify(sym_expr)
+
+        # 2. Parameterize (including bias symbols b_i)
+        self.param_expr = parameterize_expression(sym_expr, include_bias=True)
+        self.param_expr_str = str(self.param_expr)
+
+        # 3. Extract all symbols
+        all_symbols = self.param_expr.free_symbols
+        x_sym = symbols('x')
+        weight_symbols = [sym for sym in all_symbols if sym != x_sym]
+        self.w_syms = [str(sym) for sym in weight_symbols if str(sym).startswith('w')]
+        self.c_syms = [str(sym) for sym in weight_symbols if str(sym).startswith('c')]
+        self.b_syms = [str(sym) for sym in weight_symbols if str(sym).startswith('b')]
+
+        # 4. Create parameters
+        self.w_weights = nn.ParameterList()
+        self.c_weights = nn.ParameterList()
+        self.b_weights = nn.ParameterList()
+
+        for _ in self.w_syms:
+            self.w_weights.append(Parameter(torch.Tensor(out_features, in_features)))
+        for _ in self.c_syms:
+            self.c_weights.append(Parameter(torch.Tensor(out_features, 1)))
+        for _ in self.b_syms:
+            self.b_weights.append(Parameter(torch.Tensor(out_features, 1)))
+
+        self.w_names = self.w_syms
+        self.c_names = self.c_syms
+        self.b_names = self.b_syms
+
+        # 5. Additional bias (kept for compatibility, but b_i already used)
+        if bias:
+            self.bias = Parameter(torch.empty(out_features))
+        else:
+            self.register_parameter('bias', None)
+
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        for w in self.w_weights:
+            init.kaiming_uniform_(w, a=math.sqrt(5))
+        for c in self.c_weights:
+            init.normal_(c, mean=0.0, std=0.1)
+        for b in self.b_weights:
+            init.zeros_(b)
+        if self.bias is not None:
+            if len(self.w_weights) > 0:
+                fan_in, _ = init._calculate_fan_in_and_fan_out(self.w_weights[0])
+            else:
+                fan_in = self.in_features
+            bound = 1 / math.sqrt(fan_in) if fan_in > 0 else 0
+            init.uniform_(self.bias, -bound, bound)
+
+    def forward(self, x):
+        param_dict = {}
+        for name, w in zip(self.w_names, self.w_weights):
+            param_dict[name] = w
+        for name, c in zip(self.c_names, self.c_weights):
+            param_dict[name] = c
+        for name, b in zip(self.b_names, self.b_weights):
+            param_dict[name] = b
+
+        result = evaluate_expression(self.param_expr, x, param_dict, self.out_features)
+
+        # Numerical stability
+        result = torch.nan_to_num(result, nan=0.0, posinf=1e6, neginf=-1e6)
+        result = torch.clamp(result, -1e6, 1e6)
+
+        if self.bias is not None:
+            result = result + self.bias
+        return result
+
+
+# ---------- MLPClassifier ----------
 class MLPClassifier(BaseModel):
     def __init__(self,
                  neurons='x',
@@ -40,41 +159,43 @@ class MLPClassifier(BaseModel):
                  batch_size=128,
                  lr=0.001,
                  visual=False,
+                 visual_interval=100,
                  save=False,
                  fig_path=None,
-                 visual_interval=100,
                  gpu=None,
                  interval=None,
                  scheduler=None,
                  l1_reg=False,
                  l2_reg=False,
+                 mode='base',
                  ):
         r"""Construct MLPClassifier with task-based neurons.
 
-    Args:
-         neurons (str): Neuronal expression
-         layers_list (list): List of neuron counts for each hidden layer
-         activation_funcs (str): Activation functions
-         loss_function (str): Loss function for the training process
-         optimizer_name (str): Name of the optimizer algorithm
-         random_state (int): Seed for random number generators for reproducibility
-         max_iter (int): Maximum number of training iterations
-         batch_size (int): Number of samples per batch during training
-         lr (float): Learning rate for the optimizer
-         visual (boolean): Boolean indicating if training visualization is to be shown
-         save (boolean): Indicates if the training figure should be saved
-         fig_path (str or None): Path to save the training figure
-         visual_interval (int): Interval at which training visualization is updated
-         gpu (int or None): Specifies GPU configuration for training
-         interval (int): Interval of screen output during training
-         scheduler (dict): Learning rate scheduler
-         l1_reg (boolean): L1 regularization term
-         l2_reg (boolean): L2 regularization term
+        Args:
+            neurons (str): Neuronal expression
+            layers_list (list): List of neuron counts for each hidden layer
+            activation_funcs (str): Activation functions
+            loss_function (str): Loss function for the training process
+            optimizer_name (str): Name of the optimizer algorithm
+            random_state (int): Seed for random number generators for reproducibility
+            max_iter (int): Maximum number of training iterations
+            batch_size (int): Number of samples per batch during training
+            lr (float): Learning rate for the optimizer
+            visual (boolean): Boolean indicating if training visualization is to be shown
+            visual_interval (int): Interval at which training visualization is updated
+            save (boolean): Indicates if the training figure should be saved
+            fig_path (str or None): Path to save the training figure
+            gpu (int or None): Specifies GPU configuration for training
+            interval (int): Interval of screen output during training
+            scheduler (dict): Learning rate scheduler
+            l1_reg (boolean): L1 regularization term
+            l2_reg (boolean): L2 regularization term
+            mode (str): Which neuron layer implementation to use:
+                       'base'  -> BaseCustomNeuronLayer (SymPy + InnerProduct)
+                       'legacy' -> LegacyCustomNeuronLayer (from tnlearn.neurons)
         """
-
         super(MLPClassifier, self).__init__()
 
-        # Initialize parameters
         self.random_state = random_state
         self.max_iter = max_iter
         self.batch_size = batch_size
@@ -88,34 +209,91 @@ class MLPClassifier(BaseModel):
         self.scheduler = scheduler
         self.l1_reg = l1_reg
         self.l2_reg = l2_reg
+        self.mode = mode
+        if self.mode.lower() not in ('base', 'legacy'):
+            raise ValueError("mode must be 'base' or 'legacy'")
 
         if fig_path is None:
             self.fig_path = './'
         else:
             self.fig_path = fig_path
 
-        # Set device for computation
         self.gpu = gpu
         self.device = self.select_device(gpu)
 
-        # Check if visual_interval is an integer and non-zero
-        assert isinstance(self.visual_interval,
-                          int) and self.visual_interval, "visual_interval must be a non-zero integer"
+        assert isinstance(self.visual_interval, int) and self.visual_interval, "visual_interval must be a non-zero integer"
 
-        # Set default layers if layers_list is not provided
         if layers_list is None:
             self.layers_list = [50, 30, 10]
         else:
             self.layers_list = layers_list
 
-        # Convert activation function string to PyTorch activation function
-        self.activation_funcs = get_activation_function(activation_funcs) if activation_funcs else nn.ReLU()
+        # ----- scikit-learn compatible parameter storage -----
+        # Store activation function as string for get_params/set_params
+        if activation_funcs is None:
+            self.activation_funcs_str = 'relu'
+        else:
+            if not isinstance(activation_funcs, str):
+                raise ValueError("activation_funcs must be a string, got {}".format(type(activation_funcs)))
+            self.activation_funcs_str = activation_funcs
+        self.activation_funcs = get_activation_function(self.activation_funcs_str)
 
-        # Convert loss function string to PyTorch loss function
-        self.loss_function = get_loss_function(loss_function) if loss_function else nn.CrossEntropyLoss()
+        # Store loss function as string, but handle cross_entropy directly
+        if loss_function is None:
+            self.loss_function_str = 'cross_entropy'
+            self.loss_function = nn.CrossEntropyLoss()
+        else:
+            if not isinstance(loss_function, str):
+                raise ValueError("loss_function must be a string, got {}".format(type(loss_function)))
+            self.loss_function_str = loss_function
+            # Use get_loss_function for other strings, but if it's cross_entropy, use CrossEntropyLoss directly
+            if self.loss_function_str == 'cross_entropy':
+                self.loss_function = nn.CrossEntropyLoss()
+            else:
+                self.loss_function = get_loss_function(self.loss_function_str)
 
-        # Set random seed
         random_seed(self.random_state)
+
+    def get_params(self, deep=True):
+        """Get parameters for this estimator (scikit-learn compatibility)."""
+        return {
+            'neurons': self.neurons,
+            'layers_list': self.layers_list,
+            'activation_funcs': self.activation_funcs_str,
+            'loss_function': self.loss_function_str,
+            'optimizer_name': self.optimizer_name,
+            'random_state': self.random_state,
+            'max_iter': self.max_iter,
+            'batch_size': self.batch_size,
+            'lr': self.lr,
+            'visual': self.visual,
+            'visual_interval': self.visual_interval,
+            'save': self.save_fig,
+            'fig_path': self.fig_path,
+            'gpu': self.gpu,
+            'interval': self.interval,
+            'scheduler': self.scheduler,
+            'l1_reg': self.l1_reg,
+            'l2_reg': self.l2_reg,
+            'mode': self.mode,
+        }
+
+    def set_params(self, **params):
+        """Set the parameters of this estimator (scikit-learn compatibility)."""
+        for key, value in params.items():
+            setattr(self, key, value)
+        # Re-instantiate activation function if updated
+        if 'activation_funcs' in params:
+            self.activation_funcs_str = params['activation_funcs']
+            self.activation_funcs = get_activation_function(self.activation_funcs_str)
+        # Re-instantiate loss function if updated
+        if 'loss_function' in params:
+            self.loss_function_str = params['loss_function']
+            if self.loss_function_str == 'cross_entropy':
+                self.loss_function = nn.CrossEntropyLoss()
+            else:
+                self.loss_function = get_loss_function(self.loss_function_str)
+        return self
 
     def select_device(self, gpu):
         r"""Selects the training device based on the 'gpu' parameter.
@@ -123,24 +301,18 @@ class MLPClassifier(BaseModel):
         Args:
             gpu: GPU ID.
         """
-        # If gpu is None, return CPU as device
         if gpu is None:
             return torch.device("cpu")
-        # Check if CUDA is available, raise an error if it's not
         if not torch.cuda.is_available():
             raise ValueError("CUDA is not available. Training will default to CPU.")
-        # If gpu is an integer, return the corresponding CUDA device
         if isinstance(gpu, int):
             cuda_device = f'cuda:{gpu}'
             return torch.device(cuda_device)
-        # If gpu is a list or tuple, validate each element as a valid GPU index
         elif isinstance(gpu, (list, tuple)):
             for g in gpu:
                 if not isinstance(g, int) or g >= torch.cuda.device_count():
                     raise ValueError(f"Invalid GPU index {g}")
-            # Return the list of GPU indices, which will be used in DataParallel later
             return gpu
-        # Raise an error for an invalid 'gpu' parameter
         else:
             raise ValueError("Invalid 'gpu' parameter. It should be None, an integer, or a list/tuple of integers.")
 
@@ -151,20 +323,24 @@ class MLPClassifier(BaseModel):
             input_dim: The input dimension of the network.
             output_dim: The output dimension of the network.
 
-
         Returns:
             A fully connected network architecture.
         """
+        # Choose the appropriate CustomNeuronLayer class based on mode
+        if self.mode.lower() == 'legacy':
+            layer_class = LegacyCustomNeuronLayer
+        else:
+            layer_class = BaseCustomNeuronLayer
 
         layers = []
         last_dim = input_dim
-        # Iterate over the list to create each layer
         for neuron_count in self.layers_list:
-            layers.append(CustomNeuronLayer(last_dim, neuron_count, self.neurons))
+            layers.append(layer_class(last_dim, neuron_count, self.neurons))
             last_dim = neuron_count
             layers.append(self.activation_funcs)
 
-        layers.append(CustomNeuronLayer(last_dim, output_dim, self.neurons))  # Final output layer
+        # Output layer: also uses the same CustomNeuronLayer (no activation, handled by CrossEntropyLoss)
+        layers.append(layer_class(last_dim, output_dim, self.neurons))
         return nn.Sequential(*layers)
 
     def prepare_data(self, X, y):
@@ -174,7 +350,6 @@ class MLPClassifier(BaseModel):
             X (numpy ndarray): Training data.
             y (numpy ndarray): Label data.
         """
-        # Data dimension check and setting
         if not isinstance(X, np.ndarray):
             raise ValueError("X should be a NumPy array.")
         if len(X.shape) != 2:
@@ -183,16 +358,16 @@ class MLPClassifier(BaseModel):
 
         if not isinstance(y, np.ndarray):
             raise ValueError("y should be a NumPy array.")
-        self.output_dim = len(np.unique(y))
 
-        # Ensure X and y are PyTorch tensors
-        if not isinstance(X, torch.Tensor):
-            self.X = torch.tensor(X, dtype=torch.float32)
+        # Map labels to 0..n_classes-1
+        self.classes_ = np.unique(y)
+        self.class_to_idx = {val: i for i, val in enumerate(self.classes_)}
+        y_mapped = np.array([self.class_to_idx[val] for val in y])
+        self.output_dim = len(self.classes_)
 
-        if not isinstance(y, torch.Tensor):
-            self.y = torch.tensor(y, dtype=torch.long)
+        self.X = torch.tensor(X, dtype=torch.float32)
+        self.y = torch.tensor(y_mapped, dtype=torch.long)
 
-        # Dataset transformation
         trainset = TensorDataset(self.X, self.y)
         self.trainloader = DataLoader(trainset, batch_size=self.batch_size, shuffle=True)
 
@@ -203,188 +378,112 @@ class MLPClassifier(BaseModel):
             X (numpy ndarray): Training data.
             y (numpy ndarray): Label data.
         """
-        # Prepare the data
         self.prepare_data(X, y)
-
-        # Initialize lists to track losses
         self.losses = []
+        self.train_accuracies = []
 
-        # Build the neural network model based on input and output dimensions and move it to the specified device
         if self.device == torch.device("cpu"):
             self.net = self.build_model(self.input_dim, self.output_dim).to(self.device)
         else:
             self.net = self.build_model(self.input_dim, self.output_dim)
-            # If using multiple GPUs
             if isinstance(self.device, list):
                 self.net = nn.DataParallel(self.net, device_ids=self.device)
                 self.net.to(f'cuda:{self.device[0]}')
                 self.device = f'cuda:{self.device[0]}'
             else:
-                # If using a single GPU
                 self.net = self.net.to(self.device)
                 self.device = self.device
 
-        # Move the loss function to the specified device
         self.cost = self.loss_function.to(self.device)
+        self.optimizer = get_optimizer(name=self.optimizer_name, parameters=list(self.net.parameters()), lr=self.lr)
 
-        # Define the optimizer
-        self.optimizer = get_optimizer(name=self.optimizer_name,
-                                       parameters=list(self.net.parameters()),
-                                       lr=self.lr)
-
-        # Add learning rate adjustment strategy
-        if self.scheduler is not None:  # If a learning rate adjustment strategy is provided
+        if self.scheduler is not None:
             scheduler = lr_scheduler.StepLR(self.optimizer, step_size=self.scheduler["step_size"],
                                             gamma=self.scheduler["gamma"])
 
-        # Initialize lists to track training accuracies
-        self.net_train_accuracy = []
-
-        # Set the model to training mode
         self.net.train()
-
-        # Iterate through each epoch
         for epoch in range(self.max_iter):
-            self.current_epoch = epoch + 1  # Update the current epoch
-
+            self.current_epoch = epoch + 1
             running_loss = 0.0
             for inputs, labels in self.trainloader:
-                # Move inputs and labels to the specified device
                 inputs, labels = inputs.to(self.device), labels.to(self.device)
-                # Reset the gradients
                 self.optimizer.zero_grad()
-                # Forward pass
                 outputs = self.net(inputs)
-                # Calculate the loss
                 loss = self.cost(outputs, labels)
 
-                # Add L1 regularization if specified
                 if self.l1_reg:
-                    l1_regularization = torch.tensor(0., requires_grad=True).to(self.device)
-                    for param in self.net.parameters():
-                        l1_regularization = l1_regularization + torch.norm(param, 1)
-                    loss += self.l1_reg * l1_regularization
-
-                # Add L2 regularization if specified
+                    l1_loss = sum(p.abs().sum() for p in self.net.parameters())
+                    loss += self.l1_reg * l1_loss
                 if self.l2_reg:
-                    l2_regularization = torch.tensor(0., requires_grad=True).to(self.device)
-                    for param in self.net.parameters():
-                        l2_regularization = l2_regularization + torch.norm(param, 2)
-                    loss += 0.5 * self.l2_reg * l2_regularization
+                    l2_loss = sum(p.pow(2.0).sum() for p in self.net.parameters())
+                    loss += self.l2_reg * l2_loss
 
-                # Backward pass and optimization
                 loss.backward()
                 self.optimizer.step()
-
                 running_loss += loss.item()
 
-            # Update the learning rate at the end of each epoch if a scheduler is provided
             if self.scheduler is not None:
                 scheduler.step()
 
+            # Compute training accuracy
             train_accuracy = 0.0
             with torch.no_grad():
                 for inputs, labels in self.trainloader:
-                    inputs = inputs.to(self.device)
-                    labels = labels.to(self.device)
-                    predict = self.net(inputs)
-                    _, predict_class = torch.max(predict, 1)
-                    train_accuracy += (predict_class == labels).sum().item()
+                    inputs, labels = inputs.to(self.device), labels.to(self.device)
+                    outputs = self.net(inputs)
+                    _, predicted = torch.max(outputs, 1)
+                    train_accuracy += (predicted == labels).sum().item()
             train_accuracy = train_accuracy / self.X.shape[0]
 
-            # Log the progress at the specified interval.
-            if self.interval is not None and (epoch + 1) % self.interval == 0:
-                print(f'Epoch [{epoch + 1}/{self.max_iter}], Loss: {running_loss:.4f}, Accuracy:{train_accuracy:.4f}')
-
-            # Append the loss and accuracy to the history list
             self.losses.append(running_loss)
+            self.train_accuracies.append(train_accuracy)
 
-            self.net_train_accuracy.append(train_accuracy)
+            if self.interval is not None and (epoch + 1) % self.interval == 0:
+                print(f'Epoch [{epoch + 1}/{self.max_iter}], Loss: {running_loss:.4f}, Accuracy: {train_accuracy:.4f}')
 
-            # Visualize the progress if enabled and at specified intervals
-            if self.visual:
-                if epoch % self.visual_interval == 0:
-                    self.plot_progress_classification(loss=self.losses, accuracy=self.net_train_accuracy)
+            if self.visual and epoch % self.visual_interval == 0:
+                self.plot_progress_classification(loss=self.losses, accuracy=self.train_accuracies)
 
-        # Save the visualization if enabled
         if self.save_fig:
-            self.classification_savefigure(loss=self.losses, accuracy=self.net_train_accuracy, path=self.fig_path)
+            self.classification_savefigure(loss=self.losses, accuracy=self.train_accuracies, path=self.fig_path)
 
     def predict(self, X):
         r"""Use a trained model to make predictions.
 
         Args:
-            X (torch.Tensor): Data that needs to be predicted.
+            X (torch.Tensor or numpy array): Data to predict.
 
         Returns:
-            Predicted value
+            numpy array of predicted class labels (original labels).
         """
-        # Convert data to torch.Tensor if it's not already
         if not isinstance(X, torch.Tensor):
-            X = torch.Tensor(X)
-
-        # Create a TensorDataset object
+            X = torch.tensor(X, dtype=torch.float32)
         dataset = TensorDataset(X)
-        # Create a DataLoader
         data_loader = DataLoader(dataset, batch_size=self.batch_size, shuffle=False)
-
-        # Set the network to evaluation mode
         self.net.eval()
-
-        predictions = []
+        pred_indices = []
         with torch.no_grad():
             for inputs in data_loader:
-                inputs = inputs[0].to(self.device)  # Here, inputs is a list containing one element
+                inputs = inputs[0].to(self.device)
                 outputs = self.net(inputs)
-                _, predicted = torch.max(outputs.data, 1)
-                # Extend the list of predictions
-                predictions.extend(predicted.cpu().numpy())
+                _, predicted = torch.max(outputs, 1)
+                pred_indices.extend(predicted.cpu().numpy())
+        # Map indices back to original class labels
+        return self.classes_[np.array(pred_indices)]
 
-        # Return the predictions
-        return np.array(predictions)
-
-    def score(self, X_, y_):
-        r"""Evaluate the score of the model.
+    def score(self, X, y):
+        r"""Evaluate the accuracy of the model.
 
         Args:
-            X_ (numpy ndarray): Test data.
-            y_ (numpy ndarray): Label data.
+            X (numpy ndarray): Test data.
+            y (numpy ndarray): True labels.
 
         Returns:
-            accuracy
+            accuracy score
         """
-        # Ensure X and y are PyTorch tensors
-        if not isinstance(X_, torch.Tensor):
-            X_ = torch.tensor(X_, dtype=torch.float32)
-        if not isinstance(y_, torch.Tensor):
-            y_ = torch.tensor(y_, dtype=torch.long)
-
-        # Create a DataLoader
-        dataset = TensorDataset(X_, y_)
-        loader = DataLoader(dataset, batch_size=self.batch_size, shuffle=False)
-
-        # Set the network to evaluation mode
-        self.net.eval()
-        correct = 0.0
-
-        predictions = []
-        # Disable gradient calculation
-        with torch.no_grad():
-            for inputs, labels in loader:
-                # Move to the appropriate device
-                inputs, labels = inputs.to(self.device), labels.to(self.device)
-                # Forward pass
-                outputs = self.net(inputs)
-                _, predicted = torch.max(outputs.data, 1)
-                # Extend the list of predictions
-                predictions.extend(predicted.cpu().numpy())
-
-        # Set the network back to training mode
-        self.net.train()
-
-        return accuracy_score(y_, predictions)
+        pred = self.predict(X)
+        return accuracy_score(y, pred)
 
     def count_param(self):
         r"""Print the network structure and output the number of network parameters."""
-
-        summary(self.net, input_size=(self.batch_size, 1, self.X.shape[0], self.input_dim))
+        summary(self.net, input_size=(self.batch_size, self.input_dim))

--- a/tnlearn/mlpregressor.py
+++ b/tnlearn/mlpregressor.py
@@ -1,33 +1,152 @@
-# Copyright 2024 Meng WANG. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# ==============================================================================
+"""
+MLPRegressor with customizable neuron layers.
 
+This module provides two versions of CustomNeuronLayer:
+- BaseCustomNeuronLayer (default): uses SymPy parameterization with InnerProduct.
+- LegacyCustomNeuronLayer: imported from tnlearn.neurons (original implementation).
+
+Copyright (c) 2024 Meng WANG. All Rights Reserved.
+Copyright (c) 2026 Tieyun LI. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import math
 import torch
-from torch import nn
-from torch.utils.data import DataLoader, TensorDataset
+import torch.nn as nn
+from torch.nn.parameter import Parameter
+from torch.nn import init
+import sympy as sp
+from sympy import symbols, Add, Mul, Pow, sin, cos, exp, simplify, expand, sympify, Symbol, Number
 import numpy as np
 import torch.optim.lr_scheduler as lr_scheduler
-from tnlearn.neurons import CustomNeuronLayer
+from torch.utils.data import DataLoader, TensorDataset
+from torchinfo import summary
+from sklearn.metrics import r2_score
+
 from tnlearn.seeds import random_seed
 from tnlearn.activation_function import get_activation_function
 from tnlearn.loss_function import get_loss_function
 from tnlearn.optimizer import get_optimizer
 from tnlearn.base1 import BaseModel1
-from torchinfo import summary
-from sklearn.metrics import r2_score
+
+# Import legacy CustomNeuronLayer from original package
+from tnlearn.neurons import CustomNeuronLayer as LegacyCustomNeuronLayer
+
+# Import InnerProduct utilities for base mode
+from tnlearn.operator.inner_product import (
+    InnerProduct,
+    convert_pretty_to_innerproduct,
+    parameterize_expression,
+    evaluate_expression,
+)
 
 
+# ---------- Base CustomNeuronLayer (new version) ----------
+class BaseCustomNeuronLayer(nn.Module):
+    """
+    Custom neuron layer using SymPy parameterization with InnerProduct.
+    """
+    def __init__(self, in_features: int, out_features: int, symbolic_expression: str, bias: bool = True):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.raw_expr = symbolic_expression
+
+        # 1. Convert to InnerProduct format
+        expr_str = convert_pretty_to_innerproduct(symbolic_expression)
+        local_dict = {'InnerProduct': InnerProduct}
+        try:
+            sym_expr = sympify(expr_str, locals=local_dict)
+        except Exception as e:
+            raise ValueError(f"Failed to parse expression: {expr_str}\nError: {e}")
+
+        # Expand and simplify
+        sym_expr = expand(sym_expr)
+        sym_expr = simplify(sym_expr)
+
+        # 2. Parameterize
+        self.param_expr = parameterize_expression(sym_expr, include_bias=True)
+        self.param_expr_str = str(self.param_expr)
+
+        # 3. Extract all symbols
+        all_symbols = self.param_expr.free_symbols
+        x_sym = symbols('x')
+        weight_symbols = [sym for sym in all_symbols if sym != x_sym]
+        self.w_syms = [str(sym) for sym in weight_symbols if str(sym).startswith('w')]
+        self.c_syms = [str(sym) for sym in weight_symbols if str(sym).startswith('c')]
+        self.b_syms = [str(sym) for sym in weight_symbols if str(sym).startswith('b')]
+
+        # 4. Create parameters
+        self.w_weights = nn.ParameterList()
+        self.c_weights = nn.ParameterList()
+        self.b_weights = nn.ParameterList()
+
+        for _ in self.w_syms:
+            self.w_weights.append(Parameter(torch.Tensor(out_features, in_features)))
+        for _ in self.c_syms:
+            self.c_weights.append(Parameter(torch.Tensor(out_features, 1)))
+        for _ in self.b_syms:
+            self.b_weights.append(Parameter(torch.Tensor(out_features, 1)))
+
+        self.w_names = self.w_syms
+        self.c_names = self.c_syms
+        self.b_names = self.b_syms
+
+        # 5. Bias (kept for compatibility, but b_i are already used)
+        if bias:
+            self.bias = Parameter(torch.empty(out_features))
+        else:
+            self.register_parameter('bias', None)
+
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        for w in self.w_weights:
+            init.kaiming_uniform_(w, a=math.sqrt(5))
+        for c in self.c_weights:
+            init.normal_(c, mean=0.0, std=0.1)
+        for b in self.b_weights:
+            init.zeros_(b)
+        if self.bias is not None:
+            if len(self.w_weights) > 0:
+                fan_in, _ = init._calculate_fan_in_and_fan_out(self.w_weights[0])
+            else:
+                fan_in = self.in_features
+            bound = 1 / math.sqrt(fan_in) if fan_in > 0 else 0
+            init.uniform_(self.bias, -bound, bound)
+
+    def forward(self, x):
+        param_dict = {}
+        for name, w in zip(self.w_names, self.w_weights):
+            param_dict[name] = w
+        for name, c in zip(self.c_names, self.c_weights):
+            param_dict[name] = c
+        for name, b in zip(self.b_names, self.b_weights):
+            param_dict[name] = b
+
+        result = evaluate_expression(self.param_expr, x, param_dict, self.out_features)
+
+        # Numerical stability
+        result = torch.nan_to_num(result, nan=0.0, posinf=1e6, neginf=-1e6)
+        result = torch.clamp(result, -1e6, 1e6)
+
+        if self.bias is not None:
+            result = result + self.bias
+        return result
+
+
+# ---------- MLPRegressor ----------
 class MLPRegressor(BaseModel1):
     def __init__(self,
                  neurons='x',
@@ -48,33 +167,35 @@ class MLPRegressor(BaseModel1):
                  scheduler=None,
                  l1_reg=False,
                  l2_reg=False,
+                 mode='base',
                  ):
-        r""" Construct MLPRegressor with task-based neurons.
+        r"""Construct MLPRegressor with task-based neurons.
 
         Args:
-             neurons (str): Neuronal expression
-             layers_list (list): List of neuron counts for each hidden layer
-             activation_funcs (str): Activation functions
-             loss_function (str): Loss function for the training process
-             optimizer_name (str): Name of the optimizer algorithm
-             random_state (int): Seed for random number generators for reproducibility
-             max_iter (int): Maximum number of training iterations
-             batch_size (int): Number of samples per batch during training
-             lr (float): Learning rate for the optimizer
-             visual (boolean): Boolean indicating if training visualization is to be shown
-             save (boolean): Indicates if the training figure should be saved
-             fig_path (str or None): Path to save the training figure
-             visual_interval (int): Interval at which training visualization is updated
-             gpu (int or None): Specifies GPU configuration for training
-             interval (int): Interval of screen output during training
-             scheduler (dict): Learning rate scheduler
-             l1_reg (boolean): L1 regularization term
-             l2_reg (boolean): L2 regularization term
+            neurons (str): Neuronal expression
+            layers_list (list): List of neuron counts for each hidden layer
+            activation_funcs (str): Activation functions
+            loss_function (str): Loss function for the training process
+            optimizer_name (str): Name of the optimizer algorithm
+            random_state (int): Seed for random number generators for reproducibility
+            max_iter (int): Maximum number of training iterations
+            batch_size (int): Number of samples per batch during training
+            lr (float): Learning rate for the optimizer
+            visual (boolean): Boolean indicating if training visualization is to be shown
+            save (boolean): Indicates if the training figure should be saved
+            fig_path (str or None): Path to save the training figure
+            visual_interval (int): Interval at which training visualization is updated
+            gpu (int or None): Specifies GPU configuration for training
+            interval (int): Interval of screen output during training
+            scheduler (dict): Learning rate scheduler
+            l1_reg (boolean): L1 regularization term
+            l2_reg (boolean): L2 regularization term
+            mode (str): Which neuron layer implementation to use:
+                       'base'  -> BaseCustomNeuronLayer (SymPy + InnerProduct)
+                       'legacy' -> LegacyCustomNeuronLayer (from tnlearn.neurons)
         """
-
         super(MLPRegressor, self).__init__()
 
-        # Initialize the member variables with the values provided to the constructor
         self.random_state = random_state
         self.max_iter = max_iter
         self.batch_size = batch_size
@@ -88,34 +209,84 @@ class MLPRegressor(BaseModel1):
         self.scheduler = scheduler
         self.l1_reg = l1_reg
         self.l2_reg = l2_reg
+        self.mode = mode
+        if self.mode.lower() not in ('base', 'legacy'):
+            raise ValueError("mode must be 'base' or 'legacy'")
 
         if fig_path is None:
             self.fig_path = './'
         else:
             self.fig_path = fig_path
 
-        # Select the device for training based on GPU configuration
         self.gpu = gpu
         self.device = self.select_device(gpu)
 
-        # Validation to ensure that the visual_interval is an integer and not zero
         assert isinstance(self.visual_interval,
                           int) and self.visual_interval, "visual_interval must be a non-zero integer"
 
-        # Use default layers if none are provided
         if layers_list is None:
             self.layers_list = [50, 30, 10]
         else:
             self.layers_list = layers_list
 
-        # Set up the activation functions for layers if provided, otherwise use ReLU
-        self.activation_funcs = get_activation_function(activation_funcs) if activation_funcs else nn.ReLU()
+        # ----- scikit-learn compatible parameter storage -----
+        # Store activation function as string for get_params/set_params
+        if activation_funcs is None:
+            self.activation_funcs_str = 'relu'
+        else:
+            if not isinstance(activation_funcs, str):
+                raise ValueError("activation_funcs must be a string, got {}".format(type(activation_funcs)))
+            self.activation_funcs_str = activation_funcs
+        self.activation_funcs = get_activation_function(self.activation_funcs_str)
 
-        # Get the loss function; default to MSE (Mean Squared Error) if not provided
-        self.loss_function = get_loss_function(loss_function) if loss_function else nn.MSELoss()
+        # Store loss function as string
+        if loss_function is None:
+            self.loss_function_str = 'mse'
+        else:
+            if not isinstance(loss_function, str):
+                raise ValueError("loss_function must be a string, got {}".format(type(loss_function)))
+            self.loss_function_str = loss_function
+        self.loss_function = get_loss_function(self.loss_function_str)
 
-        # Set the random seed for reproducibility
         random_seed(self.random_state)
+
+    def get_params(self, deep=True):
+        """Get parameters for this estimator (scikit-learn compatibility)."""
+        return {
+            'neurons': self.neurons,
+            'layers_list': self.layers_list,
+            'activation_funcs': self.activation_funcs_str,
+            'loss_function': self.loss_function_str,
+            'optimizer_name': self.optimizer_name,
+            'random_state': self.random_state,
+            'max_iter': self.max_iter,
+            'batch_size': self.batch_size,
+            'lr': self.lr,
+            'visual': self.visual,
+            'visual_interval': self.visual_interval,
+            'save': self.save_fig,
+            'fig_path': self.fig_path,
+            'gpu': self.gpu,
+            'interval': self.interval,
+            'scheduler': self.scheduler,
+            'l1_reg': self.l1_reg,
+            'l2_reg': self.l2_reg,
+            'mode': self.mode,
+        }
+
+    def set_params(self, **params):
+        """Set the parameters of this estimator (scikit-learn compatibility)."""
+        for key, value in params.items():
+            setattr(self, key, value)
+        # Re-instantiate activation function if updated
+        if 'activation_funcs' in params:
+            self.activation_funcs_str = params['activation_funcs']
+            self.activation_funcs = get_activation_function(self.activation_funcs_str)
+        # Re-instantiate loss function if updated
+        if 'loss_function' in params:
+            self.loss_function_str = params['loss_function']
+            self.loss_function = get_loss_function(self.loss_function_str)
+        return self
 
     def select_device(self, gpu):
         r"""Selects the training device based on the 'gpu' parameter.
@@ -123,21 +294,18 @@ class MLPRegressor(BaseModel1):
         Args:
             gpu: GPU ID.
         """
-        # If GPU is not specified, use CPU for training
         if gpu is None:
             return torch.device("cpu")
         if not torch.cuda.is_available():
             raise ValueError("CUDA is not available. Training will default to CPU.")
-        # Select specific GPU if an integer index is provided
         if isinstance(gpu, int):
             cuda_device = f'cuda:{gpu}'
             return torch.device(cuda_device)
-        # If a list or tuple is provided, ensure all indexes are valid and return the GPU list
         elif isinstance(gpu, (list, tuple)):
             for g in gpu:
                 if not isinstance(g, int) or g >= torch.cuda.device_count():
                     raise ValueError(f"Invalid GPU index {g}")
-            return gpu  # Return the list of GPU indexes for DataParallel use
+            return gpu
         else:
             raise ValueError("Invalid 'gpu' parameter. It should be None, an integer, or a list/tuple of integers.")
 
@@ -148,23 +316,23 @@ class MLPRegressor(BaseModel1):
             input_dim: The input dimension of the network.
             output_dim: The output dimension of the network.
 
-
         Returns:
             A fully connected network architecture.
         """
+        # Choose the appropriate CustomNeuronLayer class based on mode
+        if self.mode.lower() == 'legacy':
+            layer_class = LegacyCustomNeuronLayer
+        else:
+            layer_class = BaseCustomNeuronLayer
 
         layers = []
         last_dim = input_dim
-        # Iterate over the list to create each layer in the neural network model
         for neuron_count in self.layers_list:
-            # Append a custom layer with specified number of neurons
-            layers.append(CustomNeuronLayer(last_dim, neuron_count, self.neurons))
+            layers.append(layer_class(last_dim, neuron_count, self.neurons))
             last_dim = neuron_count
             layers.append(self.activation_funcs)
 
-        # Add the final linear layer that outputs to the desired output dimension
         layers.append(nn.Linear(last_dim, output_dim))
-        # Compile all the layers into a single sequential model
         return nn.Sequential(*layers)
 
     def prepare_data(self, X, y):
@@ -174,7 +342,6 @@ class MLPRegressor(BaseModel1):
             X (numpy ndarray): Training data.
             y (numpy ndarray): Label data.
         """
-        # Check and set the dimensions of the input data
         if not isinstance(X, np.ndarray):
             raise ValueError("X should be a NumPy array.")
         if len(X.shape) != 2:
@@ -183,20 +350,15 @@ class MLPRegressor(BaseModel1):
 
         if not isinstance(y, np.ndarray):
             raise ValueError("y should be a NumPy array.")
-        # Automatically determine the output dimension from the target data
         self.output_dim = y.shape[1] if len(y.shape) > 1 else 1
 
-        # Convert the input and target data to torch tensors if they are not already
         if not isinstance(X, torch.Tensor):
             self.X = torch.tensor(X, dtype=torch.float32)
 
         if not isinstance(y, torch.Tensor):
             self.y = torch.tensor(y, dtype=torch.float32)
 
-        # Create dataset objects to be used with DataLoaders
         trainset = TensorDataset(self.X, self.y)
-
-        # DataLoader for the training set allows iterating over the data in batches and shuffling
         self.trainloader = DataLoader(trainset, batch_size=self.batch_size, shuffle=True)
 
     def fit(self, X, y):
@@ -206,84 +368,62 @@ class MLPRegressor(BaseModel1):
             X (numpy ndarray): Training data.
             y (numpy ndarray): Label data.
         """
-        # Prepare the data by performing any necessary preprocessing
         self.prepare_data(X, y)
-
-        # Initialize the lists for tracking loss
         self.losses = []
 
-        # Build the model and move it to the appropriate device (CPU or GPU).
         if self.device == torch.device("cpu"):
             self.net = self.build_model(self.input_dim, self.output_dim).to(self.device)
         else:
             self.net = self.build_model(self.input_dim, self.output_dim)
-            # Check if multiple GPUs are used.
             if isinstance(self.device, list):
                 self.net = nn.DataParallel(self.net, device_ids=self.device)
                 self.net.to(f'cuda:{self.device[0]}')
                 self.device = f'cuda:{self.device[0]}'
-
-            else:  # Single GPU case.
+            else:
                 self.net = self.net.to(self.device)
                 self.device = self.device
 
-        # Move the loss function to the device.
         self.cost = self.loss_function.to(self.device)
         self.optimizer = get_optimizer(name=self.optimizer_name, parameters=list(self.net.parameters()),
                                        lr=self.lr)
 
-        # Initialize the scheduler if provided for learning rate adjustment.
         if self.scheduler is not None:
             scheduler = lr_scheduler.StepLR(self.optimizer, step_size=self.scheduler["step_size"],
                                             gamma=self.scheduler["gamma"])
 
-        # Set the network to training mode.
         self.net.train()
         for epoch in range(self.max_iter):
-            self.current_epoch = epoch + 1  # Update the current epoch counter.
-
+            self.current_epoch = epoch + 1
             running_loss = 0.0
-            # Iterate over the training data.
             for inputs, targets in self.trainloader:
-                # Move the inputs and targets to the same device as the model.
                 inputs, targets = inputs.to(self.device), targets.to(self.device).reshape(-1, 1)
-
                 self.optimizer.zero_grad()
                 outputs = self.net(inputs)
                 loss = self.cost(outputs, targets)
 
-                # L1 regularization if enabled.
                 if self.l1_reg:
                     l1_loss = sum(p.abs().sum() for p in self.net.parameters())
                     loss += self.l1_reg * l1_loss
 
-                # L2 regularization if enabled.
                 if self.l2_reg:
                     l2_loss = sum(p.pow(2.0).sum() for p in self.net.parameters())
                     loss += self.l2_reg * l2_loss
 
                 loss.backward()
                 self.optimizer.step()
-
                 running_loss += loss.item()
 
-            # Step the scheduler to update the learning rate if applicable.
             if self.scheduler is not None:
                 scheduler.step()
 
-            # Log the progress at the specified interval.
             if self.interval is not None and (epoch + 1) % self.interval == 0:
                 print(f'Epoch [{epoch + 1}/{self.max_iter}], Loss: {running_loss:.4f}')
 
-            # Append the loss (and optionally accuracy) to the lists for tracking.
             self.losses.append(running_loss)
 
-            # Visualization of the training progress if enabled.
-            if self.visual:
-                if epoch % self.visual_interval == 0:
-                    self.plot_progress_regression(loss=self.losses)
+            if self.visual and epoch % self.visual_interval == 0:
+                self.plot_progress_regression(loss=self.losses)
 
-        # Save the visualization if enabled
         if self.save_fig:
             self.regression_savefigure(loss=self.losses, path=self.fig_path)
 
@@ -296,27 +436,20 @@ class MLPRegressor(BaseModel1):
         Returns:
             Predicted value
         """
-        # Convert the input to a PyTorch tensor if it is not one already
         if not isinstance(X, torch.Tensor):
             X = torch.Tensor(X)
 
-        # Create a TensorDataset with the tensor
         dataset = TensorDataset(X)
         data_loader = DataLoader(dataset, batch_size=self.batch_size, shuffle=False)
 
         self.net.eval()
-
         predictions = []
         with torch.no_grad():
             for inputs in data_loader:
                 inputs = inputs[0].to(self.device)
                 outputs = self.net(inputs)
-                # Move outputs to cpu and convert to numpy, then add to predictions list
                 predictions.extend(outputs.cpu().numpy())
-
-        # Flatten the predictions list to a 1D numpy array
-        predictions = np.array(predictions).flatten()
-        return predictions
+        return np.array(predictions).flatten()
 
     def score(self, X, y):
         r"""Evaluate the coefficient of determination.
@@ -328,31 +461,9 @@ class MLPRegressor(BaseModel1):
         Returns:
             Coefficient of determination.
         """
-
-        # Convert the input to a PyTorch tensor if it is not one already
-        if not isinstance(X, torch.Tensor):
-            X = torch.Tensor(X)
-
-        # Create a TensorDataset with the tensor
-        dataset = TensorDataset(X)
-        data_loader = DataLoader(dataset, batch_size=self.batch_size, shuffle=False)
-
-        self.net.eval()
-
-        predictions = []
-        with torch.no_grad():
-            for inputs in data_loader:
-                inputs = inputs[0].to(self.device)
-                outputs = self.net(inputs)
-                # Move outputs to cpu and convert to numpy, then add to predictions list
-                predictions.extend(outputs.cpu().numpy())
-
-        # Flatten the predictions list to a 1D numpy array
-        predictions = np.array(predictions).flatten()
-
-        return r2_score(y, predictions)
+        pred = self.predict(X)
+        return r2_score(y, pred)
 
     def count_param(self):
         r"""Print the network structure and output the number of network parameters."""
-
-        summary(self.net, input_size=(self.batch_size, 1, 10, self.input_dim))
+        summary(self.net, input_size=(self.batch_size, self.input_dim))

--- a/tnlearn/modules/TNconv.py
+++ b/tnlearn/modules/TNconv.py
@@ -1,12 +1,39 @@
+"""
+Convolutional layers with symbolic aggregation supporting inner‑product cross terms.
+
+This module provides 1D, 2D, 3D convolution and transposed convolution layers where
+the aggregation function is defined by a symbolic expression.
+
+Two modes are supported:
+- base (default): Uses SymPy parameterization with InnerProduct support.
+- legacy: Uses simple eval-based expression parsing (original implementation).
+
+Copyright (c) 2026 Tieyun LI. All Rights Reserved.
+"""
+
+import math
+import re
+from typing import Union, Tuple, Optional, List, Literal
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-import math
-from torch.nn import init
-from typing import Union, Tuple
+from torch.nn import init, Parameter
+from sympy import symbols, Add, Mul, Pow, sin, cos, exp, simplify, expand, sympify, Symbol, Number
 
-__all__ = ['TNConv1d', 'TNConv2d', 'TNConv3d', 'TNConvTranspose1d', 'TNConvTranspose2d', 'TNConvTranspose3d']
+from tnlearn.operator.inner_product import (
+    InnerProduct,
+    convert_pretty_to_innerproduct,
+    is_inner_product,
+    replace_numbers,
+)
 
+__all__ = [
+    'TNConv1d', 'TNConv2d', 'TNConv3d',
+    'TNConvTranspose1d', 'TNConvTranspose2d', 'TNConvTranspose3d'
+]
+
+# ---------- Global eval environment for legacy mode ----------
 _EVAL_GLOBALS = {
     'torch': torch,
     'np': __import__('numpy'),
@@ -14,64 +41,241 @@ _EVAL_GLOBALS = {
     'F': F,
 }
 
+# ---------- Internal helper: base mode parameterization ----------
+def _process_inner_product(ip, counter):
+    left = ip.left
+    right = ip.right
+    new_left = replace_numbers(left, counter, False)
+    new_right = expand(simplify(right))
+    return InnerProduct(new_left, new_right)
+
+def parameterize_term_conv(term, counter):
+    if term.is_number:
+        return 0
+    if is_inner_product(term):
+        new_ip = _process_inner_product(term, counter)
+        if term.left.is_Number:
+            return new_ip
+        else:
+            c = symbols('c%d' % counter['c'])
+            counter['c'] += 1
+            return Mul(c, new_ip)
+    if isinstance(term, Mul):
+        inner_products = []
+        non_inner = []
+        created_param = False
+        for factor in term.args:
+            if factor.is_number:
+                continue
+            elif is_inner_product(factor):
+                new_ip = _process_inner_product(factor, counter)
+                if factor.left.is_Number:
+                    created_param = True
+                inner_products.append(new_ip)
+            else:
+                non_inner.append(factor)
+        if non_inner:
+            merged = Mul(*non_inner)
+            old_w = counter['w']
+            merged = replace_numbers(merged, counter, False)
+            if counter['w'] > old_w:
+                created_param = True
+            w = symbols('w%d' % counter['w'])
+            counter['w'] += 1
+            created_param = True
+            inner_products.append(InnerProduct(w, merged))
+        if not inner_products:
+            return 1
+        result = Mul(*inner_products) if len(inner_products) > 1 else inner_products[0]
+        if not created_param:
+            c = symbols('c%d' % counter['c'])
+            counter['c'] += 1
+            result = Mul(c, result)
+        return result
+    new_expr = replace_numbers(term, counter, False)
+    w = symbols('w%d' % counter['w'])
+    counter['w'] += 1
+    return InnerProduct(w, new_expr)
+
+def parameterize_expression_conv(expr):
+    if isinstance(expr, Add):
+        terms = list(expr.args)
+    else:
+        terms = [expr]
+    counter = {'w': 1, 'b': 1, 'c': 1}
+    new_terms = []
+    for t in terms:
+        pt = parameterize_term_conv(t, counter)
+        if pt != 0:
+            new_terms.append(pt)
+    if not new_terms:
+        return 0
+    return Add(*new_terms) if len(new_terms) > 1 else new_terms[0]
+
+def _check_inner_product_legality(expr, x_sym):
+    if is_inner_product(expr):
+        left, right = expr.args
+        if not (isinstance(left, Symbol) and str(left).startswith('w')):
+            raise ValueError(f"InnerProduct left argument must be a weight symbol (w_i), got {left}")
+        if not right.has(x_sym):
+            raise ValueError(f"InnerProduct right argument must depend on input 'x', got {right}")
+        for sym in right.free_symbols:
+            if str(sym).startswith('w'):
+                raise ValueError(f"InnerProduct right argument contains weight symbol {sym}, which is not allowed.")
+        _check_inner_product_legality(right, x_sym)
+    elif isinstance(expr, (Add, Mul, Pow)):
+        for arg in expr.args:
+            _check_inner_product_legality(arg, x_sym)
+    elif hasattr(expr, 'args') and not isinstance(expr, (Symbol, Number)):
+        for arg in expr.args:
+            _check_inner_product_legality(arg, x_sym)
+
+# ---------- Legacy mode helpers ----------
+def _split_terms(expr: str):
+    terms = []
+    current = []
+    depth = 0
+    for ch in expr:
+        if ch == '(':
+            depth += 1
+        elif ch == ')':
+            depth -= 1
+        if depth == 0 and ch in ('+', '-'):
+            terms.append(''.join(current))
+            current = [ch]
+        else:
+            current.append(ch)
+    if current:
+        terms.append(''.join(current))
+    return terms
+
+def _parse_expression(expr: str):
+    expr = expr.replace(' ', '')
+    terms = _split_terms(expr)
+    x_terms = []
+    for t in terms:
+        t = t.lstrip('+-')
+        if 'x' in t:
+            if '@' in t:
+                var_expr = t.split('@', 1)[1]
+            else:
+                var_expr = t
+            x_terms.append(var_expr)
+    return x_terms
+
+# ---------- Base class for N‑D convolution ----------
 class _TNConvNd(nn.Module):
-    """Base class: N-dimensional convolution layer supporting symbolic expressions."""
+    """
+    Base class for N‑dimensional convolution with symbolic aggregation.
+
+    Args:
+        in_channels, out_channels, kernel_size, stride, padding, groups, dilation,
+        padding_mode, bias, device, dtype, ndim, is_transposed, output_padding
+        mode (str): 'base' (SymPy+InnerProduct) or 'legacy' (eval-based)
+        symbolic_expression (str): expression defining aggregation.
+    """
+    __constants__ = ['in_channels', 'out_channels', 'groups', 'kernel_size',
+                     'stride', 'padding', 'dilation', 'padding_mode',
+                     'output_padding', 'symbolic_expression', 'ndim', 'is_transposed', 'mode']
+
     def __init__(self,
                  in_channels: int,
                  out_channels: int,
                  kernel_size: Union[int, Tuple[int, ...]],
                  stride: Union[int, Tuple[int, ...]] = 1,
-                 padding: Union[int, Tuple[int, ...]] = 0,
+                 padding: Union[int, Tuple[int, ...], str] = 0,
                  symbolic_expression: str = 'x',
                  groups: int = 1,
                  dilation: Union[int, Tuple[int, ...]] = 1,
-                 padding_mode: str = 'zeros',
+                 padding_mode: Literal['zeros', 'reflect', 'replicate', 'circular'] = 'zeros',
                  bias: bool = True,
                  device=None,
                  dtype=None,
-                 ndim: int = 2):   # ndim specifies convolution dimension 1/2/3
+                 ndim: int = 2,
+                 is_transposed: bool = False,
+                 output_padding: Union[int, Tuple[int, ...]] = 0,
+                 mode: str = 'base'):
         super().__init__()
         self.ndim = ndim
         self.in_channels = int(in_channels)
         self.out_channels = int(out_channels)
         self.groups = int(groups)
+        self.is_transposed = is_transposed
+        self.mode = mode.lower()
+        if self.mode not in ('base', 'legacy'):
+            raise ValueError("mode must be 'base' or 'legacy'")
 
-        # Convert to tuples uniformly
-        self.kernel_size = self._ntuple(ndim)(kernel_size)
-        self.stride = self._ntuple(ndim)(stride)
-        self.padding = self._ntuple(ndim)(padding)
-        self.dilation = self._ntuple(ndim)(dilation)
-
+        ntuple = self._ntuple(ndim)
+        self.kernel_size = ntuple(kernel_size)
+        self.stride = ntuple(stride)
+        self.padding = ntuple(padding) if not isinstance(padding, str) else padding
+        self.dilation = ntuple(dilation)
+        self.output_padding = ntuple(output_padding) if is_transposed else None
         self.padding_mode = padding_mode
         self.symbolic_expression = symbolic_expression
 
-        # Validate groups
         if in_channels % groups != 0:
             raise ValueError(f'in_channels ({in_channels}) must be divisible by groups ({groups})')
+        if is_transposed and out_channels % groups != 0:
+            raise ValueError(f'out_channels ({out_channels}) must be divisible by groups ({groups})')
 
-        # Parse the expression
-        self.terms = self._parse_expression(symbolic_expression)
-        if not self.terms:
-            self.terms = ['x']
+        # Determine weight shape
+        if is_transposed:
+            out_ch_per_group = out_channels // groups
+            w_shape = (in_channels, out_ch_per_group, *self.kernel_size)
+        else:
+            in_ch_per_group = in_channels // groups
+            w_shape = (out_channels, in_ch_per_group, *self.kernel_size)
 
-        # Pre-compile basis functions
-        self.funcs = []
-        for expr in self.terms:
-            try:
-                fn = eval('lambda x: ' + expr, _EVAL_GLOBALS)
-            except Exception as e:
-                print(f"Warning: eval failed for '{expr}', using identity. Error: {e}")
-                fn = lambda x: x
-            self.funcs.append(fn)
+        if self.mode == 'base':
+            # ---------- Base mode (SymPy) ----------
+            converted_str = convert_pretty_to_innerproduct(symbolic_expression)
+            raw_expr = sympify(converted_str, locals={'InnerProduct': InnerProduct})
+            raw_expr = expand(simplify(raw_expr))
+            self.param_expr = parameterize_expression_conv(raw_expr)
 
-        # Create weights
-        in_ch_per_group = in_channels // groups
-        # Weight shape: (out_channels, in_ch_per_group, *kernel_size)
-        self.weights = nn.ParameterList()
-        for _ in self.terms:
-            w = nn.Parameter(torch.empty(out_channels, in_ch_per_group, *self.kernel_size,
-                                         device=device, dtype=dtype))
-            self.weights.append(w)
+            x_sym = symbols('x')
+            all_symbols = self.param_expr.free_symbols if self.param_expr != 0 else set()
+            weight_symbols = [sym for sym in all_symbols if sym != x_sym]
+            w_syms = [str(sym) for sym in weight_symbols if str(sym).startswith('w')]
+            c_syms = [str(sym) for sym in weight_symbols if str(sym).startswith('c')]
+
+            if self.param_expr != 0:
+                _check_inner_product_legality(self.param_expr, x_sym)
+
+            self.weights = nn.ParameterDict()
+            for sym in w_syms:
+                self.weights[str(sym)] = nn.Parameter(torch.empty(w_shape, device=device, dtype=dtype))
+
+            spatial_shape = (1,) * ndim
+            self.coeffs = nn.ParameterDict()
+            for sym in c_syms:
+                self.coeffs[str(sym)] = nn.Parameter(torch.empty(out_channels, *spatial_shape, device=device, dtype=dtype))
+
+            self._x_sym = x_sym
+            self._base_initialized = True
+            self._legacy_initialized = False
+        else:
+            # ---------- Legacy mode (eval) ----------
+            self.terms = _parse_expression(symbolic_expression)
+            if not self.terms:
+                self.terms = ['x']
+
+            self.funcs = []
+            for expr in self.terms:
+                try:
+                    fn = eval('lambda x: ' + expr, _EVAL_GLOBALS)
+                except Exception as e:
+                    print(f"Legacy: eval failed for '{expr}', using identity. Error: {e}")
+                    fn = lambda x: x
+                self.funcs.append(fn)
+
+            self.weights = nn.ParameterList()
+            for _ in self.terms:
+                self.weights.append(nn.Parameter(torch.empty(w_shape, device=device, dtype=dtype)))
+
+            self._base_initialized = False
+            self._legacy_initialized = True
 
         # Bias
         if bias:
@@ -81,24 +285,7 @@ class _TNConvNd(nn.Module):
 
         self.reset_parameters()
 
-    def __getstate__(self):
-        state = self.__dict__.copy()
-        state.pop('funcs', None)
-        return state
-
-    def __setstate__(self, state):
-        self.__dict__.update(state)
-        self.funcs = []
-        for expr in self.terms:
-            try:
-                fn = eval('lambda x: ' + expr, _EVAL_GLOBALS)
-            except Exception as e:
-                print(f"Warning: eval failed for '{expr}', using identity. Error: {e}")
-                fn = lambda x: x
-            self.funcs.append(fn)
-
     def _ntuple(self, n):
-        """Return a function that converts input to a tuple of length n."""
         def parse(x):
             if isinstance(x, (int, float)):
                 return tuple([int(x)] * n)
@@ -112,337 +299,267 @@ class _TNConvNd(nn.Module):
         return parse
 
     def reset_parameters(self):
-        for w in self.weights:
-            init.kaiming_uniform_(w, a=math.sqrt(5))
+        if self.mode == 'base':
+            for w in self.weights.values():
+                init.kaiming_uniform_(w, a=math.sqrt(5))
+            for c in self.coeffs.values():
+                fan_in = self.in_channels
+                bound = 1 / math.sqrt(fan_in) if fan_in > 0 else 0
+                init.uniform_(c, -bound, bound)
+        else:  # legacy
+            for w in self.weights:
+                init.kaiming_uniform_(w, a=math.sqrt(5))
         if self.bias is not None:
-            fan_in, _ = init._calculate_fan_in_and_fan_out(self.weights[0])
+            fan_in = self.in_channels
             bound = 1 / math.sqrt(fan_in) if fan_in > 0 else 0
             init.uniform_(self.bias, -bound, bound)
 
-    def _split_terms(self, expr: str):
-        terms = []
-        current = []
-        depth = 0
-        for ch in expr:
-            if ch == '(':
-                depth += 1
-            elif ch == ')':
-                depth -= 1
-            if depth == 0 and ch in ('+', '-'):
-                terms.append(''.join(current))
-                current = [ch]
-            else:
-                current.append(ch)
-        if current:
-            terms.append(''.join(current))
-        return terms
-
-    def _parse_expression(self, expr: str):
-        expr = expr.replace(' ', '')
-        terms = self._split_terms(expr)
-        x_terms = []
-        for t in terms:
-            t = t.lstrip('+-')
-            if 'x' in t:
-                if '@' in t:
-                    var_expr = t.split('@', 1)[1]
-                else:
-                    var_expr = t
-                x_terms.append(var_expr)
-        return x_terms
-
-    def forward(self, x):
-        # Handle padding modes (non-zero padding requires manual pad)
+    def extra_repr(self) -> str:
+        s = f'in_channels={self.in_channels}, out_channels={self.out_channels}'
+        s += f', kernel_size={self.kernel_size}'
+        if self.stride != (1,) * self.ndim:
+            s += f', stride={self.stride}'
+        if self.padding != (0,) * self.ndim and not isinstance(self.padding, str):
+            s += f', padding={self.padding}'
+        elif isinstance(self.padding, str):
+            s += f', padding="{self.padding}"'
+        if self.dilation != (1,) * self.ndim:
+            s += f', dilation={self.dilation}'
+        if self.is_transposed and self.output_padding != (0,) * self.ndim:
+            s += f', output_padding={self.output_padding}'
+        if self.groups != 1:
+            s += f', groups={self.groups}'
         if self.padding_mode != 'zeros':
-            # Build pad tuple according to dimension: F.pad order is (left, right, top, bottom, front, back) etc.
-            # For 1D: (pad_w, pad_w)
-            # For 2D: (pad_w, pad_w, pad_h, pad_h)
-            # For 3D: (pad_w, pad_w, pad_h, pad_h, pad_d, pad_d)
-            pad = []
-            for size in reversed(self.padding):   # start from the last dimension
-                pad.extend([size, size])
-            x = F.pad(x, pad, mode=self.padding_mode)
-            conv_padding = tuple([0] * self.ndim)   # no extra padding in convolution
-        else:
-            conv_padding = self.padding
+            s += f', padding_mode={self.padding_mode}'
+        if self.bias is None:
+            s += ', bias=False'
+        if self.symbolic_expression != 'x':
+            s += f', symbolic_expression="{self.symbolic_expression}"'
+        if self.mode != 'base':
+            s += f', mode="{self.mode}"'
+        return s
 
-        # Accumulate outputs from each basis function
-        result = None
-        for func, weight in zip(self.funcs, self.weights):
-            transformed = func(x)
-            out = self._conv_forward(transformed, weight, conv_padding)
-            if result is None:
-                result = out          # direct assignment, no copy
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # -------- Padding handling (same for both modes) --------
+        if self.padding_mode != 'zeros':
+            pad = []
+            if isinstance(self.padding, str):
+                if self.padding == 'valid':
+                    pad = [0] * (2 * self.ndim)
+                elif self.padding == 'same':
+                    for d, k, s, dil in zip(range(self.ndim), self.kernel_size,
+                                            self.stride, self.dilation):
+                        total_pad = dil * (k - 1)
+                        left = total_pad // 2
+                        right = total_pad - left
+                        pad = [right, left] + pad
+                else:
+                    raise ValueError(f"Unsupported padding string: {self.padding}")
             else:
-                result = result + out # in-place addition would be ideal, but PyTorch doesn't support in-place for tensors from different operations; this is fine
+                for size in reversed(self.padding):
+                    pad.extend([size, size])
+            x_padded = F.pad(x, pad, mode=self.padding_mode)
+            conv_padding = tuple([0] * self.ndim)
+        else:
+            x_padded = x
+            conv_padding = self.padding if not isinstance(self.padding, str) else (0,) * self.ndim
+
+        # -------- Choose convolution function --------
+        if self.is_transposed:
+            conv_fn = getattr(F, f'conv_transpose{self.ndim}d')
+            conv_kwargs = {
+                'stride': self.stride,
+                'padding': conv_padding,
+                'output_padding': self.output_padding,
+                'dilation': self.dilation,
+                'groups': self.groups,
+            }
+        else:
+            conv_fn = getattr(F, f'conv{self.ndim}d')
+            conv_kwargs = {
+                'stride': self.stride,
+                'padding': conv_padding,
+                'dilation': self.dilation,
+                'groups': self.groups,
+            }
+
+        # -------- Mode-specific forward --------
+        if self.mode == 'base':
+            def conv_wrapper(inp, weight):
+                return conv_fn(inp, weight, **conv_kwargs)
+
+            subs = {}
+            for name, param in self.weights.items():
+                subs[symbols(name)] = param
+            for name, param in self.coeffs.items():
+                subs[symbols(name)] = param
+
+            result = self._eval_conv_expr(self.param_expr, x_padded, subs, conv_wrapper, self.is_transposed)
+        else:  # legacy
+            result = None
+            for func, weight in zip(self.funcs, self.weights):
+                transformed = func(x_padded)
+                out = conv_fn(transformed, weight, **conv_kwargs)
+                if result is None:
+                    result = out
+                else:
+                    result = result + out
 
         if self.bias is not None:
-            # Bias shape: (out_channels,), need to expand dimensions to match output
-            # Output shape is (N, C, *spatial), bias is added on the C dimension
             result = result + self.bias.view(1, -1, *([1] * self.ndim))
 
         return result
 
-    def _conv_forward(self, x, weight, padding):
-        """Subclasses override this method to call the corresponding F.conv1d/2d/3d."""
-        raise NotImplementedError
+    def _eval_conv_expr(self, expr, x_tensor, subs, conv_fn, is_transposed=False):
+        """Base mode evaluation (recursive SymPy evaluation)."""
+        if expr.is_Number:
+            return torch.tensor(float(expr), device=x_tensor.device).reshape(1, 1, *([1]*self.ndim))
+
+        if expr.is_Symbol:
+            if expr == self._x_sym:
+                return x_tensor
+            else:
+                return subs[expr]
+
+        if expr.is_Add:
+            result = self._eval_conv_expr(expr.args[0], x_tensor, subs, conv_fn, is_transposed)
+            for arg in expr.args[1:]:
+                result = result + self._eval_conv_expr(arg, x_tensor, subs, conv_fn, is_transposed)
+            return result
+
+        if expr.is_Mul:
+            result = self._eval_conv_expr(expr.args[0], x_tensor, subs, conv_fn, is_transposed)
+            for arg in expr.args[1:]:
+                result = result * self._eval_conv_expr(arg, x_tensor, subs, conv_fn, is_transposed)
+            return result
+
+        if expr.is_Pow:
+            base = self._eval_conv_expr(expr.base, x_tensor, subs, conv_fn, is_transposed)
+            exp = self._eval_conv_expr(expr.exp, x_tensor, subs, conv_fn, is_transposed)
+            return base ** exp
+
+        if expr.func.__name__ == 'sin':
+            return torch.sin(self._eval_conv_expr(expr.args[0], x_tensor, subs, conv_fn, is_transposed))
+        if expr.func.__name__ == 'cos':
+            return torch.cos(self._eval_conv_expr(expr.args[0], x_tensor, subs, conv_fn, is_transposed))
+        if expr.func.__name__ == 'exp':
+            return torch.exp(self._eval_conv_expr(expr.args[0], x_tensor, subs, conv_fn, is_transposed))
+
+        if is_inner_product(expr):
+            left = expr.left
+            right = expr.right
+            left_val = self._eval_conv_expr(left, x_tensor, subs, conv_fn, is_transposed)
+            right_val = self._eval_conv_expr(right, x_tensor, subs, conv_fn, is_transposed)
+
+            if isinstance(left_val, Parameter) and left_val.dim() == self.ndim + 2:
+                return conv_fn(right_val, left_val)
+            else:
+                prod = left_val * right_val
+                dims_to_sum = list(range(1, prod.dim()))
+                return prod.sum(dim=dims_to_sum, keepdim=True)
+
+        raise NotImplementedError(f"Unsupported expression node: {expr}")
 
 
-# ---------- Subclass implementations ----------
+# ========== Concrete convolution classes ==========
 class TNConv1d(_TNConvNd):
-    def __init__(self, in_channels, out_channels, kernel_size, stride=1, padding=0,
-                 symbolic_expression='x', groups=1, dilation=1, padding_mode='zeros',
-                 bias=True, device=None, dtype=None):
+    def __init__(self, in_channels: int, out_channels: int, kernel_size: Union[int, Tuple[int]],
+                 stride: Union[int, Tuple[int]] = 1,
+                 padding: Union[int, Tuple[int], str] = 0,
+                 symbolic_expression: str = 'x',
+                 groups: int = 1,
+                 dilation: Union[int, Tuple[int]] = 1,
+                 padding_mode: Literal['zeros', 'reflect', 'replicate', 'circular'] = 'zeros',
+                 bias: bool = True,
+                 device=None, dtype=None,
+                 mode: str = 'base'):
         super().__init__(in_channels, out_channels, kernel_size, stride, padding,
                          symbolic_expression, groups, dilation, padding_mode,
-                         bias, device, dtype, ndim=1)
-
-    def _conv_forward(self, x, weight, padding):
-        return F.conv1d(x, weight, None,
-                        stride=self.stride,
-                        padding=padding,
-                        dilation=self.dilation,
-                        groups=self.groups)
+                         bias, device, dtype, ndim=1, is_transposed=False,
+                         output_padding=0, mode=mode)
 
 
 class TNConv2d(_TNConvNd):
-    def __init__(self, in_channels, out_channels, kernel_size, stride=1, padding=0,
-                 symbolic_expression='x', groups=1, dilation=1, padding_mode='zeros',
-                 bias=True, device=None, dtype=None):
+    def __init__(self, in_channels: int, out_channels: int, kernel_size: Union[int, Tuple[int, int]],
+                 stride: Union[int, Tuple[int, int]] = 1,
+                 padding: Union[int, Tuple[int, int], str] = 0,
+                 symbolic_expression: str = 'x',
+                 groups: int = 1,
+                 dilation: Union[int, Tuple[int, int]] = 1,
+                 padding_mode: Literal['zeros', 'reflect', 'replicate', 'circular'] = 'zeros',
+                 bias: bool = True,
+                 device=None, dtype=None,
+                 mode: str = 'base'):
         super().__init__(in_channels, out_channels, kernel_size, stride, padding,
                          symbolic_expression, groups, dilation, padding_mode,
-                         bias, device, dtype, ndim=2)
-
-    def _conv_forward(self, x, weight, padding):
-        return F.conv2d(x, weight, None,
-                        stride=self.stride,
-                        padding=padding,
-                        dilation=self.dilation,
-                        groups=self.groups)
+                         bias, device, dtype, ndim=2, is_transposed=False,
+                         output_padding=0, mode=mode)
 
 
 class TNConv3d(_TNConvNd):
-    def __init__(self, in_channels, out_channels, kernel_size, stride=1, padding=0,
-                 symbolic_expression='x', groups=1, dilation=1, padding_mode='zeros',
-                 bias=True, device=None, dtype=None):
-        super().__init__(in_channels, out_channels, kernel_size, stride, padding,
-                         symbolic_expression, groups, dilation, padding_mode,
-                         bias, device, dtype, ndim=3)
-
-    def _conv_forward(self, x, weight, padding):
-        return F.conv3d(x, weight, None,
-                        stride=self.stride,
-                        padding=padding,
-                        dilation=self.dilation,
-                        groups=self.groups)
-
-
-# ---------- Transposed convolution base class ----------
-class _TNConvTransposeNd(nn.Module):
-    """Base class: N-dimensional transposed convolution layer supporting symbolic expressions."""
-    def __init__(self,
-                 in_channels: int,
-                 out_channels: int,
-                 kernel_size: Union[int, Tuple[int, ...]],
-                 stride: Union[int, Tuple[int, ...]] = 1,
-                 padding: Union[int, Tuple[int, ...]] = 0,
-                 output_padding: Union[int, Tuple[int, ...]] = 0,
+    def __init__(self, in_channels: int, out_channels: int, kernel_size: Union[int, Tuple[int, int, int]],
+                 stride: Union[int, Tuple[int, int, int]] = 1,
+                 padding: Union[int, Tuple[int, int, int], str] = 0,
                  symbolic_expression: str = 'x',
                  groups: int = 1,
-                 dilation: Union[int, Tuple[int, ...]] = 1,
+                 dilation: Union[int, Tuple[int, int, int]] = 1,
+                 padding_mode: Literal['zeros', 'reflect', 'replicate', 'circular'] = 'zeros',
                  bias: bool = True,
-                 device=None,
-                 dtype=None,
-                 ndim: int = 2):
-        super().__init__()
-        self.ndim = ndim
-        self.in_channels = int(in_channels)
-        self.out_channels = int(out_channels)
-        self.groups = int(groups)
-
-        # Convert to tuples uniformly
-        self.kernel_size = self._ntuple(ndim)(kernel_size)
-        self.stride = self._ntuple(ndim)(stride)
-        self.padding = self._ntuple(ndim)(padding)
-        self.output_padding = self._ntuple(ndim)(output_padding)
-        self.dilation = self._ntuple(ndim)(dilation)
-
-        self.symbolic_expression = symbolic_expression
-
-        # Validate groups
-        if in_channels % groups != 0:
-            raise ValueError(f'in_channels ({in_channels}) must be divisible by groups ({groups})')
-        if out_channels % groups != 0:
-            raise ValueError(f'out_channels ({out_channels}) must be divisible by groups ({groups})')
-
-        # Parse the expression
-        self.terms = self._parse_expression(symbolic_expression)
-        if not self.terms:
-            self.terms = ['x']
-
-        # Pre-compile basis functions
-        self.funcs = []
-        for expr in self.terms:
-            try:
-                fn = eval('lambda x: ' + expr, _EVAL_GLOBALS)
-            except Exception as e:
-                print(f"Warning: eval failed for '{expr}', using identity. Error: {e}")
-                fn = lambda x: x
-            self.funcs.append(fn)
-
-        # Create weights (transposed conv weight shape: (in_channels, out_channels // groups, *kernel_size))
-        out_ch_per_group = out_channels // groups
-        self.weights = nn.ParameterList()
-        for _ in self.terms:
-            w = nn.Parameter(torch.empty(in_channels, out_ch_per_group, *self.kernel_size,
-                                         device=device, dtype=dtype))
-            self.weights.append(w)
-
-        # Bias
-        if bias:
-            self.bias = nn.Parameter(torch.empty(out_channels, device=device, dtype=dtype))
-        else:
-            self.register_parameter('bias', None)
-
-        self.reset_parameters()
-
-    def __getstate__(self):
-        state = self.__dict__.copy()
-        state.pop('funcs', None)
-        return state
-
-    def __setstate__(self, state):
-        self.__dict__.update(state)
-        self.funcs = []
-        for expr in self.terms:
-            try:
-                fn = eval('lambda x: ' + expr, _EVAL_GLOBALS)
-            except Exception as e:
-                print(f"Warning: eval failed for '{expr}', using identity. Error: {e}")
-                fn = lambda x: x
-            self.funcs.append(fn)
-
-    def _ntuple(self, n):
-        def parse(x):
-            if isinstance(x, (int, float)):
-                return tuple([int(x)] * n)
-            elif isinstance(x, (tuple, list)):
-                if len(x) == n:
-                    return tuple(int(v) for v in x)
-                else:
-                    raise ValueError(f'Expected tuple of length {n}, got {len(x)}')
-            else:
-                raise TypeError(f'Unsupported type: {type(x)}')
-        return parse
-
-    def reset_parameters(self):
-        for w in self.weights:
-            init.kaiming_uniform_(w, a=math.sqrt(5))
-        if self.bias is not None:
-            fan_in, _ = init._calculate_fan_in_and_fan_out(self.weights[0])
-            bound = 1 / math.sqrt(fan_in) if fan_in > 0 else 0
-            init.uniform_(self.bias, -bound, bound)
-
-    def _split_terms(self, expr: str):
-        terms = []
-        current = []
-        depth = 0
-        for ch in expr:
-            if ch == '(':
-                depth += 1
-            elif ch == ')':
-                depth -= 1
-            if depth == 0 and ch in ('+', '-'):
-                terms.append(''.join(current))
-                current = [ch]
-            else:
-                current.append(ch)
-        if current:
-            terms.append(''.join(current))
-        return terms
-
-    def _parse_expression(self, expr: str):
-        expr = expr.replace(' ', '')
-        terms = self._split_terms(expr)
-        x_terms = []
-        for t in terms:
-            t = t.lstrip('+-')
-            if 'x' in t:
-                if '@' in t:
-                    var_expr = t.split('@', 1)[1]
-                else:
-                    var_expr = t
-                x_terms.append(var_expr)
-        return x_terms
-
-    def forward(self, x):
-        # Accumulate outputs from each basis function
-        result = None
-        for func, weight in zip(self.funcs, self.weights):
-            transformed = func(x)
-            out = self._conv_forward(transformed, weight)
-            if result is None:
-                result = out
-            else:
-                result = result + out
-
-        if self.bias is not None:
-            result = result + self.bias.view(1, -1, *([1] * self.ndim))
-
-        return result
-
-    def _conv_forward(self, x, weight):
-        """Subclasses override this method to call the corresponding F.conv_transpose1d/2d/3d."""
-        raise NotImplementedError
-
-
-# ---------- Transposed convolution subclasses ----------
-class TNConvTranspose1d(_TNConvTransposeNd):
-    def __init__(self, in_channels, out_channels, kernel_size, stride=1, padding=0,
-                 output_padding=0, symbolic_expression='x', groups=1, dilation=1,
-                 bias=True, device=None, dtype=None):
+                 device=None, dtype=None,
+                 mode: str = 'base'):
         super().__init__(in_channels, out_channels, kernel_size, stride, padding,
-                         output_padding, symbolic_expression, groups, dilation,
-                         bias, device, dtype, ndim=1)
-
-    def _conv_forward(self, x, weight):
-        return F.conv_transpose1d(x, weight, None,
-                                  stride=self.stride,
-                                  padding=self.padding,
-                                  output_padding=self.output_padding,
-                                  dilation=self.dilation,
-                                  groups=self.groups)
+                         symbolic_expression, groups, dilation, padding_mode,
+                         bias, device, dtype, ndim=3, is_transposed=False,
+                         output_padding=0, mode=mode)
 
 
-class TNConvTranspose2d(_TNConvTransposeNd):
-    def __init__(self, in_channels, out_channels, kernel_size, stride=1, padding=0,
-                 output_padding=0, symbolic_expression='x', groups=1, dilation=1,
-                 bias=True, device=None, dtype=None):
+# ========== Transposed convolution classes ==========
+class TNConvTranspose1d(_TNConvNd):
+    def __init__(self, in_channels: int, out_channels: int, kernel_size: Union[int, Tuple[int]],
+                 stride: Union[int, Tuple[int]] = 1,
+                 padding: Union[int, Tuple[int]] = 0,
+                 output_padding: Union[int, Tuple[int]] = 0,
+                 symbolic_expression: str = 'x',
+                 groups: int = 1,
+                 dilation: Union[int, Tuple[int]] = 1,
+                 bias: bool = True,
+                 device=None, dtype=None,
+                 mode: str = 'base'):
         super().__init__(in_channels, out_channels, kernel_size, stride, padding,
-                         output_padding, symbolic_expression, groups, dilation,
-                         bias, device, dtype, ndim=2)
-
-    def _conv_forward(self, x, weight):
-        return F.conv_transpose2d(x, weight, None,
-                                  stride=self.stride,
-                                  padding=self.padding,
-                                  output_padding=self.output_padding,
-                                  dilation=self.dilation,
-                                  groups=self.groups)
+                         symbolic_expression, groups, dilation, 'zeros',
+                         bias, device, dtype, ndim=1, is_transposed=True,
+                         output_padding=output_padding, mode=mode)
 
 
-class TNConvTranspose3d(_TNConvTransposeNd):
-    def __init__(self, in_channels, out_channels, kernel_size, stride=1, padding=0,
-                 output_padding=0, symbolic_expression='x', groups=1, dilation=1,
-                 bias=True, device=None, dtype=None):
+class TNConvTranspose2d(_TNConvNd):
+    def __init__(self, in_channels: int, out_channels: int, kernel_size: Union[int, Tuple[int, int]],
+                 stride: Union[int, Tuple[int, int]] = 1,
+                 padding: Union[int, Tuple[int, int]] = 0,
+                 output_padding: Union[int, Tuple[int, int]] = 0,
+                 symbolic_expression: str = 'x',
+                 groups: int = 1,
+                 dilation: Union[int, Tuple[int, int]] = 1,
+                 bias: bool = True,
+                 device=None, dtype=None,
+                 mode: str = 'base'):
         super().__init__(in_channels, out_channels, kernel_size, stride, padding,
-                         output_padding, symbolic_expression, groups, dilation,
-                         bias, device, dtype, ndim=3)
+                         symbolic_expression, groups, dilation, 'zeros',
+                         bias, device, dtype, ndim=2, is_transposed=True,
+                         output_padding=output_padding, mode=mode)
 
-    def _conv_forward(self, x, weight):
-        return F.conv_transpose3d(x, weight, None,
-                                  stride=self.stride,
-                                  padding=self.padding,
-                                  output_padding=self.output_padding,
-                                  dilation=self.dilation,
-                                  groups=self.groups)
+
+class TNConvTranspose3d(_TNConvNd):
+    def __init__(self, in_channels: int, out_channels: int, kernel_size: Union[int, Tuple[int, int, int]],
+                 stride: Union[int, Tuple[int, int, int]] = 1,
+                 padding: Union[int, Tuple[int, int, int]] = 0,
+                 output_padding: Union[int, Tuple[int, int, int]] = 0,
+                 symbolic_expression: str = 'x',
+                 groups: int = 1,
+                 dilation: Union[int, Tuple[int, int, int]] = 1,
+                 bias: bool = True,
+                 device=None, dtype=None,
+                 mode: str = 'base'):
+        super().__init__(in_channels, out_channels, kernel_size, stride, padding,
+                         symbolic_expression, groups, dilation, 'zeros',
+                         bias, device, dtype, ndim=3, is_transposed=True,
+                         output_padding=output_padding, mode=mode)

--- a/tnlearn/modules/TNlinear.py
+++ b/tnlearn/modules/TNlinear.py
@@ -1,11 +1,33 @@
+"""
+Linear layer with symbolic aggregation supporting inner‑product cross terms.
+
+This module provides a fully connected layer where the aggregation function is defined
+by a symbolic expression. Two modes are supported:
+- base (default): Uses SymPy parameterization with InnerProduct support.
+- legacy: Uses simple eval-based expression parsing (original implementation).
+
+Copyright (c) 2026 Tieyun LI. All Rights Reserved.
+"""
+
+from __future__ import annotations
+
+import math
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-import math
 from torch.nn import init
+from sympy import symbols, Add, Mul, Pow, sin, cos, exp, simplify, expand, sympify, Symbol
+
+from tnlearn.operator.inner_product import (
+    InnerProduct,
+    convert_pretty_to_innerproduct,
+    parameterize_expression,
+    is_inner_product,
+)
 
 __all__ = ['TNLinear']
 
+# ---------- Global eval environment for legacy mode ----------
 _EVAL_GLOBALS = {
     'torch': torch,
     'np': __import__('numpy'),
@@ -13,51 +35,216 @@ _EVAL_GLOBALS = {
     'F': F,
 }
 
+
+# ---------- Base mode evaluation engine (SymPy) ----------
+def eval_sympy_expr(expr, subs):
+    """
+    Recursively evaluate a SymPy expression with torch tensors.
+
+    Args:
+        expr: SymPy expression node.
+        subs: Dictionary mapping Symbol -> torch.Tensor.
+
+    Returns:
+        torch.Tensor: Result of the expression.
+    """
+    if expr.is_Number:
+        device = next(iter(subs.values())).device
+        return torch.tensor(float(expr), device=device)
+    if expr.is_Symbol:
+        return subs[expr]
+    if expr.is_Add:
+        terms = [eval_sympy_expr(arg, subs) for arg in expr.args]
+        result = terms[0]
+        for t in terms[1:]:
+            result = result + t
+        return result
+    if expr.is_Mul:
+        result = eval_sympy_expr(expr.args[0], subs)
+        for arg in expr.args[1:]:
+            result = result * eval_sympy_expr(arg, subs)
+        return result
+    if expr.is_Pow:
+        return eval_sympy_expr(expr.base, subs) ** eval_sympy_expr(expr.exp, subs)
+    if expr.func.__name__ == 'sin':
+        return torch.sin(eval_sympy_expr(expr.args[0], subs))
+    if expr.func.__name__ == 'cos':
+        return torch.cos(eval_sympy_expr(expr.args[0], subs))
+    if expr.func.__name__ == 'exp':
+        return torch.exp(eval_sympy_expr(expr.args[0], subs))
+    if expr.func.__name__ == 'tanh':
+        return torch.tanh(eval_sympy_expr(expr.args[0], subs))
+    if is_inner_product(expr):
+        a = eval_sympy_expr(expr.args[0], subs)
+        b = eval_sympy_expr(expr.args[1], subs)
+        return (a * b).sum(dim=-1, keepdim=True)
+    raise NotImplementedError(f"Unsupported expression: {expr}")
+
+
+def evaluate_expression(expr, x_tensor, param_dict, out_dim):
+    """
+    Evaluate the parameterized expression for each output dimension.
+
+    Args:
+        expr: SymPy expression (parameterized).
+        x_tensor: Input tensor of shape (..., in_features).
+        param_dict: nn.ParameterDict mapping symbol names to parameters.
+        out_dim: Number of output features.
+
+    Returns:
+        torch.Tensor: Output of shape (..., out_dim).
+    """
+    results = []
+    x_sym = symbols('x')
+    for j in range(out_dim):
+        subs = {x_sym: x_tensor}
+        for sym_str, param in param_dict.items():
+            sym_obj = symbols(sym_str)
+            # Take the j-th row, keep dimension (1, ...)
+            subs[sym_obj] = param[j:j+1]
+        val = eval_sympy_expr(expr, subs)
+        # Ensure the last dimension is 1 for concatenation
+        if val.dim() == 1:
+            val = val.unsqueeze(-1)
+        results.append(val)
+    # Concatenate along the last dimension (feature dimension)
+    return torch.cat(results, dim=-1)
+
+
+# ---------- Legacy mode helpers ----------
+def _split_terms(expr: str):
+    """Split expression by top-level '+' and '-' while respecting parentheses."""
+    terms = []
+    current = []
+    depth = 0
+    for ch in expr:
+        if ch == '(':
+            depth += 1
+        elif ch == ')':
+            depth -= 1
+        if depth == 0 and ch in ('+', '-'):
+            terms.append(''.join(current))
+            current = [ch]
+        else:
+            current.append(ch)
+    if current:
+        terms.append(''.join(current))
+    return terms
+
+
+def _parse_expression(expr: str):
+    """Extract all sub‑expressions containing 'x', ignoring pure constant terms."""
+    expr = expr.replace(' ', '')
+    terms = _split_terms(expr)
+    x_terms = []
+    for t in terms:
+        t = t.lstrip('+-')
+        if 'x' in t:
+            # If '@' is present, keep only the part after '@' (the variable expression)
+            if '@' in t:
+                var_expr = t.split('@', 1)[1]
+            else:
+                var_expr = t
+            x_terms.append(var_expr)
+    return x_terms
+
+
+# ---------- TNLinear class ----------
 class TNLinear(nn.Module):
-    r"""Custom fully connected layer that supports basis function combinations defined by symbolic expressions.
+    r"""
+    A fully connected layer with custom symbolic aggregation.
+
+    The layer accepts a symbolic expression using `x` as input. Two modes are available:
+    - base (default): Uses SymPy parameterization with InnerProduct support.
+    - legacy: Uses eval-based parsing (original implementation).
 
     Args:
         in_features (int): Number of input features.
         out_features (int): Number of output features.
-        symbolic_expression (str): Symbolic expression, e.g., 'x + sin(x) + 0.1@x**2', where 'x' denotes the input.
-        bias (bool): Whether to use bias, default True.
-        device (torch.device, optional): Device for weights and bias.
-        dtype (torch.dtype, optional): Data type for weights and bias.
+        symbolic_expression (str): Symbolic expression using `x` as input.
+            Example: 'x + sin(x) + <2, x>' becomes learnable weights.
+        bias (bool): If True, adds a learnable bias (independent of expression).
+        device (torch.device, optional): Device for parameters.
+        dtype (torch.dtype, optional): Data type for parameters.
+        mode (str): 'base' or 'legacy'. Default 'base'.
     """
-
     def __init__(self,
                  in_features: int,
                  out_features: int,
                  symbolic_expression: str = 'x',
                  bias: bool = True,
                  device=None,
-                 dtype=None):
+                 dtype=None,
+                 mode: str = 'base'):
         super().__init__()
         self.in_features = int(in_features)
         self.out_features = int(out_features)
         self.symbolic_expression = symbolic_expression
+        self.bias_flag = bias
+        self.device = device
+        self.dtype = dtype
+        self.mode = mode.lower()
+        if self.mode not in ('base', 'legacy'):
+            raise ValueError("mode must be 'base' or 'legacy'")
 
-        # Parse the expression to extract basis terms
-        self.terms = self._parse_expression(symbolic_expression)
-        if not self.terms:
-            self.terms = ['x']    # fallback to linear
+        if self.mode == 'base':
+            # ---------- Base mode (SymPy) ----------
+            # 1. Convert and parameterize expression
+            converted_str = convert_pretty_to_innerproduct(symbolic_expression)
+            raw_expr = sympify(converted_str, locals={'InnerProduct': InnerProduct})
+            raw_expr = expand(simplify(raw_expr))
+            self.param_expr = parameterize_expression(raw_expr, include_bias=False)
 
-        # Pre-compile basis functions into lambdas for faster forward pass
-        self.funcs = []
-        for expr in self.terms:
-            try:
-                fn = eval('lambda x: ' + expr, _EVAL_GLOBALS)
-            except Exception as e:
-                print(f"Warning: eval failed for '{expr}', using identity. Error: {e}")
-                fn = lambda x: x
-            self.funcs.append(fn)
+            # 2. Extract symbols: w_i (weights) and c_i (coefficients)
+            all_symbols = self.param_expr.free_symbols if self.param_expr != 0 else set()
+            x_sym = symbols('x')
+            weight_symbols = [sym for sym in all_symbols if sym != x_sym]
+            w_syms = [sym for sym in weight_symbols if str(sym).startswith('w')]
+            c_syms = [sym for sym in weight_symbols if str(sym).startswith('c')]
 
-        # Create combined weight: shape (out_features, in_features * num_terms)
-        self.num_terms = len(self.terms)
-        self.weight = nn.Parameter(
-            torch.empty(out_features, self.in_features * self.num_terms,
-                        device=device, dtype=dtype)
-        )
+            # 3. Create parameter dict
+            self.param_dict = nn.ParameterDict()
+            for sym in w_syms:
+                name = str(sym)
+                self.param_dict[name] = nn.Parameter(
+                    torch.empty(out_features, in_features, device=device, dtype=dtype)
+                )
+            for sym in c_syms:
+                name = str(sym)
+                self.param_dict[name] = nn.Parameter(
+                    torch.empty(out_features, 1, device=device, dtype=dtype)
+                )
+
+            self._w_syms = w_syms
+            self._c_syms = c_syms
+            self._x_sym = x_sym
+            self._base_initialized = True
+            self._legacy_initialized = False
+
+        else:  # legacy mode
+            # ---------- Legacy mode (eval) ----------
+            self.terms = _parse_expression(symbolic_expression)
+            if not self.terms:
+                self.terms = ['x']    # fallback to linear
+
+            # Pre-compile basis functions into lambdas
+            self.funcs = []
+            for expr in self.terms:
+                try:
+                    fn = eval('lambda x: ' + expr, _EVAL_GLOBALS)
+                except Exception as e:
+                    print(f"Legacy: eval failed for '{expr}', using identity. Error: {e}")
+                    fn = lambda x: x
+                self.funcs.append(fn)
+
+            # Create combined weight: shape (out_features, in_features * num_terms)
+            self.num_terms = len(self.terms)
+            self.weight = nn.Parameter(
+                torch.empty(out_features, self.in_features * self.num_terms,
+                            device=device, dtype=dtype)
+            )
+            self._base_initialized = False
+            self._legacy_initialized = True
 
         # Bias (shared single bias)
         if bias:
@@ -67,70 +254,83 @@ class TNLinear(nn.Module):
 
         self.reset_parameters()
 
-    def __getstate__(self):
-        state = self.__dict__.copy()
-        state.pop('funcs', None)   # lambdas are not serializable
-        return state
-
-    def __setstate__(self, state):
-        self.__dict__.update(state)
-        # Rebuild funcs
-        self.funcs = []
-        for expr in self.terms:
-            try:
-                fn = eval('lambda x: ' + expr, _EVAL_GLOBALS)
-            except Exception as e:
-                print(f"Warning: eval failed for '{expr}', using identity. Error: {e}")
-                fn = lambda x: x
-            self.funcs.append(fn)
-
     def reset_parameters(self):
-        r"""Initialize weights and bias using Kaiming uniform initialization."""
-        init.kaiming_uniform_(self.weight, a=math.sqrt(5))
+        if self.mode == 'base':
+            for name, param in self.param_dict.items():
+                if name.startswith('w'):
+                    init.kaiming_uniform_(param, a=math.sqrt(5))
+                elif name.startswith('c'):
+                    fan_in = self.in_features
+                    bound = 1 / math.sqrt(fan_in) if fan_in > 0 else 0
+                    init.uniform_(param, -bound, bound)
+        else:  # legacy
+            init.kaiming_uniform_(self.weight, a=math.sqrt(5))
+
         if self.bias is not None:
-            fan_in, _ = init._calculate_fan_in_and_fan_out(self.weight)
+            fan_in = self.in_features
             bound = 1 / math.sqrt(fan_in) if fan_in > 0 else 0
             init.uniform_(self.bias, -bound, bound)
 
-    def _split_terms(self, expr: str):
-        """Split expression by top-level '+' and '-' while respecting parentheses."""
-        terms = []
-        current = []
-        depth = 0
-        for ch in expr:
-            if ch == '(':
-                depth += 1
-            elif ch == ')':
-                depth -= 1
-            if depth == 0 and ch in ('+', '-'):
-                terms.append(''.join(current))
-                current = [ch]
-            else:
-                current.append(ch)
-        if current:
-            terms.append(''.join(current))
-        return terms
-
-    def _parse_expression(self, expr: str):
-        """Extract all sub‑expressions containing 'x', ignoring pure constant terms."""
-        expr = expr.replace(' ', '')
-        terms = self._split_terms(expr)
-        x_terms = []
-        for t in terms:
-            t = t.lstrip('+-')
-            if 'x' in t:
-                # If '@' is present, keep only the part after '@' (the variable expression)
-                if '@' in t:
-                    var_expr = t.split('@', 1)[1]
-                else:
-                    var_expr = t
-                x_terms.append(var_expr)
-        return x_terms
-
     def forward(self, x):
-        r"""Forward pass: single linear transformation after feature augmentation, plus bias."""
-        # Compute all basis functions and concatenate (augmented features)
-        augmented = torch.cat([func(x) for func in self.funcs], dim=-1)
-        # Single linear transformation
-        out = F.linear(augmented, self.weight, self.bias)
+        """
+        Forward pass.
+
+        Args:
+            x (torch.Tensor): Input tensor of shape (..., in_features).
+
+        Returns:
+            torch.Tensor: Output tensor of shape (..., out_features).
+        """
+        if self.mode == 'base':
+            out = evaluate_expression(self.param_expr, x, self.param_dict, self.out_features)
+        else:  # legacy
+            # Compute all basis functions and concatenate (augmented features)
+            augmented = torch.cat([func(x) for func in self.funcs], dim=-1)
+            out = F.linear(augmented, self.weight, None)
+
+        if self.bias is not None:
+            out = out + self.bias
         return out
+
+    def extra_repr(self):
+        mode_str = f', mode="{self.mode}"' if self.mode != 'base' else ''
+        return (f'in_features={self.in_features}, out_features={self.out_features}, '
+                f'bias={self.bias is not None}, symbolic_expression="{self.symbolic_expression}"'
+                f'{mode_str}')
+
+    # ---------- Serialization support ----------
+    def __getstate__(self):
+        """
+        Remove non‑picklable attributes (SymPy objects or lambdas) before saving.
+        """
+        state = self.__dict__.copy()
+        # Remove SymPy expressions and symbols (base mode)
+        state.pop('param_expr', None)
+        state.pop('_x_sym', None)
+        # Remove lambdas (legacy mode)
+        state.pop('funcs', None)
+        # Keep all other attributes (including parameters)
+        return state
+
+    def __setstate__(self, state):
+        """
+        Restore the object and rebuild SymPy expression or lambdas from stored strings.
+        """
+        self.__dict__.update(state)
+        if self.mode == 'base':
+            # Rebuild param_expr from symbolic_expression
+            converted_str = convert_pretty_to_innerproduct(self.symbolic_expression)
+            raw_expr = sympify(converted_str, locals={'InnerProduct': InnerProduct})
+            raw_expr = expand(simplify(raw_expr))
+            self.param_expr = parameterize_expression(raw_expr, include_bias=False)
+            self._x_sym = symbols('x')
+        else:  # legacy
+            # Rebuild funcs from self.terms
+            self.funcs = []
+            for expr in self.terms:
+                try:
+                    fn = eval('lambda x: ' + expr, _EVAL_GLOBALS)
+                except Exception as e:
+                    print(f"Legacy: eval failed for '{expr}', using identity. Error: {e}")
+                    fn = lambda x: x
+                self.funcs.append(fn)

--- a/tnlearn/modules/TNrnn.py
+++ b/tnlearn/modules/TNrnn.py
@@ -1,17 +1,13 @@
 """
-Recurrent neural network layers with custom neuron aggregation.
+Recurrent neural network layers with custom neuron aggregation supporting inner‑product cross terms.
 
-This module provides RNN, LSTM, GRU and their cell variants where the input
-is first transformed by a user‑defined symbolic expression (e.g., 'x + torch.sin(x)')
-before being fed into the recurrent computation. The transformation is applied
-element‑wise to the input features and the results are concatenated, effectively
-augmenting the input dimension with learnable non‑linearities.
+Two modes are available:
+- base (default): Uses custom cell implementation with TNLinear and manual loop.
+- legacy: Uses input augmentation + native PyTorch RNN (RNN, LSTM, GRU) modules.
 
-Based on PyTorch's torch.nn.modules.rnn.
+Copyright (c) 2026 Tieyun LI. All Rights Reserved.
 """
 
-import math
-import warnings
 from typing import List, Optional, Tuple, Union
 
 import torch
@@ -19,43 +15,54 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch import Tensor
 from torch.nn import Parameter, init
-from torch.nn.utils.rnn import PackedSequence
+from torch.nn.utils.rnn import PackedSequence, pack_padded_sequence, pad_packed_sequence
 
 from .TNlinear import TNLinear
 
 __all__ = [
     'TNRNNBase', 'TNRNN', 'TNLSTM', 'TNGRU',
-    'TNRNNCellBase', 'TNRNNCell', 'TNLSTMCell', 'TNGRUCell'
+    'TNRNNCell', 'TNLSTMCell', 'TNGRUCell'
 ]
 
-# ---------- Global evaluation environment for expression parsing ----------
+# ---------- Helper functions (shared) ----------
+
+def _stack_states(states: List[Tensor], batch_first: bool) -> Tensor:
+    if batch_first:
+        return torch.stack(states, dim=1)
+    else:
+        return torch.stack(states, dim=0)
+
+
+def _unbind_states(output: Tensor, batch_first: bool) -> List[Tensor]:
+    if batch_first:
+        return [output[:, t, :] for t in range(output.size(1))]
+    else:
+        return [output[t, :, :] for t in range(output.size(0))]
+
+
+def _reverse_sequence(inputs: Tensor, seq_lengths: Optional[Tensor] = None,
+                      batch_first: bool = False) -> Tensor:
+    if seq_lengths is None:
+        if batch_first:
+            return inputs.flip(dims=(1,))
+        else:
+            return inputs.flip(dims=(0,))
+    else:
+        return inputs.flip(dims=(1,) if batch_first else (0,))
+
+
+# ---------- Legacy mode helpers (expression parsing) ----------
 _EVAL_GLOBALS = {
     'torch': torch,
     'np': __import__('numpy'),
-    'math': math,
+    'math': __import__('math'),
     'F': F,
 }
 
 
 def _parse_expression(expr: str) -> list:
-    """
-    Parses a symbolic expression and returns a list of callable basis functions.
-
-    The expression is split at the top‑level '+' and '-' operators (respecting
-    parentheses). Only sub‑expressions that contain 'x' are kept; each such
-    sub‑expression is compiled into a lambda function that takes a tensor `x`
-    and returns the transformed tensor. If a term contains '@', the part after
-    '@' is used as the variable expression (the coefficient is ignored).
-
-    Args:
-        expr (str): The symbolic expression, e.g., 'x + torch.sin(x)'.
-
-    Returns:
-        list: A list of callable functions, each accepting a tensor and
-        returning a tensor. If no valid 'x' term is found, returns [lambda x: x].
-    """
+    """Parse symbolic expression and return list of callable basis functions."""
     expr = expr.replace(' ', '')
-    # Split at top‑level '+' and '-', ignoring parentheses
     terms = []
     current = []
     depth = 0
@@ -76,7 +83,6 @@ def _parse_expression(expr: str) -> list:
     for t in terms:
         t = t.lstrip('+-')
         if 'x' in t:
-            # If '@' is present, use the part after it as the variable expression
             if '@' in t:
                 var_expr = t.split('@', 1)[1]
             else:
@@ -84,73 +90,39 @@ def _parse_expression(expr: str) -> list:
             try:
                 fn = eval('lambda x: ' + var_expr, _EVAL_GLOBALS)
             except Exception as e:
-                print(f"Warning: eval failed for '{var_expr}', using identity. Error: {e}")
+                print(f"Legacy: eval failed for '{var_expr}', using identity. Error: {e}")
                 fn = lambda x: x
             funcs.append(fn)
     if not funcs:
-        funcs = [lambda x: x]   # fallback to linear
+        funcs = [lambda x: x]
     return funcs
 
 
 def _augment_input(x: Tensor, funcs: list) -> Tensor:
-    """
-    Applies all basis functions to the input and concatenates the results.
-
-    Args:
-        x (Tensor): Input tensor of shape (..., feature_dim).
-        funcs (list): List of callable functions.
-
-    Returns:
-        Tensor: Augmented tensor with shape (..., feature_dim * len(funcs)).
-    """
+    """Apply all basis functions and concatenate along last dimension."""
     augmented = [func(x) for func in funcs]
     return torch.cat(augmented, dim=-1)
 
 
-# ---------- Multi‑layer RNN base (feature augmentation + native RNN) ----------
+# ========== Multi‑layer RNN base ==========
 
-class TNRNNBase(nn.Module):
-    """
-    Base class for multi‑layer RNNs with custom neuron aggregation.
-
-    This class augments the input by applying the basis functions from the
-    symbolic expression and concatenating the results, then delegates the
-    actual recurrent computation to PyTorch's native RNN, LSTM, or GRU.
-    This approach leverages the efficient `_VF` implementations.
-
-    Args:
-        mode (str): One of 'RNN', 'LSTM', 'GRU'.
-        input_size (int): The number of expected features in the input.
-        hidden_size (int): The number of features in the hidden state.
-        num_layers (int): Number of recurrent layers. Default: 1.
-        bias (bool): If False, the layer does not use bias weights. Default: True.
-        batch_first (bool): If True, input and output tensors are provided as
-            (batch, seq, feature). Default: False.
-        dropout (float): If non‑zero, introduces a Dropout layer on the outputs
-            of each RNN layer except the last. Default: 0.0.
-        bidirectional (bool): If True, becomes a bidirectional RNN. Default: False.
-        symbolic_expression (str): Symbolic expression defining the basis functions.
-            Default: 'x'.
-        device (torch.device, optional): Device for the parameters.
-        dtype (torch.dtype, optional): Data type for the parameters.
-    """
+class _TNRNNBase(nn.Module):
     __constants__ = ['input_size', 'hidden_size', 'num_layers', 'bias',
-                     'batch_first', 'dropout', 'bidirectional', 'symbolic_expression']
+                     'batch_first', 'dropout', 'bidirectional', 'symbolic_expression',
+                     'mode', 'rnn_type']
 
-    def __init__(self,
-                 mode: str,
-                 input_size: int,
-                 hidden_size: int,
-                 num_layers: int = 1,
-                 bias: bool = True,
-                 batch_first: bool = False,
-                 dropout: float = 0.0,
-                 bidirectional: bool = False,
+    def __init__(self, cell_factory, mode: str, rnn_type: str,
+                 input_size: int, hidden_size: int, num_layers: int = 1,
+                 bias: bool = True, batch_first: bool = False,
+                 dropout: float = 0.0, bidirectional: bool = False,
                  symbolic_expression: str = 'x',
-                 device=None,
-                 dtype=None):
+                 device=None, dtype=None):
         super().__init__()
-        self.mode = mode
+        self.mode = mode.lower()
+        if self.mode not in ('base', 'legacy'):
+            raise ValueError("mode must be 'base' or 'legacy'")
+        self.rnn_type = rnn_type  # 'RNN', 'LSTM', or 'GRU'
+
         self.original_input_size = input_size
         self.hidden_size = hidden_size
         self.num_layers = num_layers
@@ -159,44 +131,222 @@ class TNRNNBase(nn.Module):
         self.dropout = dropout
         self.bidirectional = bidirectional
         self.symbolic_expression = symbolic_expression
+        self.device = device
+        self.dtype = dtype
 
-        # Parse expression into basis functions
-        self.funcs = _parse_expression(symbolic_expression)
-        self.num_funcs = len(self.funcs)
-        self.augmented_input_size = input_size * self.num_funcs
+        self.num_directions = 2 if bidirectional else 1
+        self.num_cells = num_layers * self.num_directions
 
-        # Create the native RNN module
-        rnn_cls = {'RNN': nn.RNN, 'LSTM': nn.LSTM, 'GRU': nn.GRU}[mode]
-        self.rnn = rnn_cls(
-            input_size=self.augmented_input_size,
-            hidden_size=hidden_size,
-            num_layers=num_layers,
-            bias=bias,
-            batch_first=batch_first,
-            dropout=dropout,
-            bidirectional=bidirectional,
-            device=device,
-            dtype=dtype
-        )
+        if self.mode == 'legacy':
+            # ---------- Legacy mode: input augmentation + native RNN ----------
+            self.funcs = _parse_expression(symbolic_expression)
+            self.num_funcs = len(self.funcs)
+            self.augmented_input_size = input_size * self.num_funcs
 
-    def _augment(self, x: Tensor) -> Tensor:
-        """Augments the input by applying all basis functions and concatenating."""
-        augmented = [func(x) for func in self.funcs]
-        return torch.cat(augmented, dim=-1)
+            rnn_cls = {'RNN': nn.RNN, 'LSTM': nn.LSTM, 'GRU': nn.GRU}[rnn_type]
+            self.rnn = rnn_cls(
+                input_size=self.augmented_input_size,
+                hidden_size=hidden_size,
+                num_layers=num_layers,
+                bias=bias,
+                batch_first=batch_first,
+                dropout=dropout,
+                bidirectional=bidirectional,
+                device=device,
+                dtype=dtype
+            )
+            # For RNN, set nonlinearity if present
+            if rnn_type == 'RNN' and hasattr(self, 'nonlinearity'):
+                self.rnn.nonlinearity = self.nonlinearity
 
-    def forward(self, input: Tensor, hx: Optional[Tensor] = None):
-        """
-        Forward pass of the RNN.
+        else:
+            # ---------- Base mode: custom cells and manual loop ----------
+            self.cells = nn.ModuleList()
+            for layer in range(num_layers):
+                layer_input_size = input_size if layer == 0 else hidden_size * (2 if bidirectional else 1)
+                for direction in range(2 if bidirectional else 1):
+                    cell = cell_factory(
+                        layer_input_size, hidden_size, bias,
+                        symbolic_expression, device, dtype
+                    )
+                    self.cells.append(cell)
 
-        Args:
-            input (Tensor): Input tensor. Shape depends on batch_first.
-            hx (Tensor, optional): Initial hidden state. If not provided, defaults to zeros.
+            if dropout > 0.0:
+                self.dropout_layer = nn.Dropout(dropout)
+            else:
+                self.dropout_layer = None
 
-        Returns:
-            output, hidden_state: Same as the native RNN.
-        """
-        aug_input = self._augment(input)
-        return self.rnn(aug_input, hx)
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        """Parameters are initialised by the submodules."""
+        pass
+
+    def _default_initial_state(self, batch_size: int, device: torch.device):
+        num = self.num_layers * self.num_directions
+        if self.mode == 'legacy':
+            return None
+        else:
+            if self.rnn_type == 'LSTM':
+                h = torch.zeros(num, batch_size, self.hidden_size, device=device, dtype=self.dtype)
+                c = torch.zeros(num, batch_size, self.hidden_size, device=device, dtype=self.dtype)
+                return (h, c)
+            else:
+                return torch.zeros(num, batch_size, self.hidden_size, device=device, dtype=self.dtype)
+
+    def _prepare_state(self, state, batch_size: int, device: torch.device):
+        if self.mode == 'legacy':
+            return state
+        else:
+            if self.rnn_type == 'LSTM':
+                h, c = state
+                if h.dim() == 2:
+                    h = h.unsqueeze(0)
+                    c = c.unsqueeze(0)
+                    h = h.expand(self.num_layers * self.num_directions, -1, -1).contiguous()
+                    c = c.expand(self.num_layers * self.num_directions, -1, -1).contiguous()
+                elif h.dim() == 3 and h.size(0) == 1:
+                    h = h.expand(self.num_layers * self.num_directions, -1, -1).contiguous()
+                    c = c.expand(self.num_layers * self.num_directions, -1, -1).contiguous()
+                return (h, c)
+            else:
+                if state.dim() == 2:
+                    state = state.unsqueeze(0)
+                    state = state.expand(self.num_layers * self.num_directions, -1, -1).contiguous()
+                return state
+
+    def _forward_impl_base(self, input: Tensor, state: Optional[Union[Tensor, Tuple[Tensor, Tensor]]],
+                           seq_lengths: Optional[Tensor] = None) -> Tuple[Tensor, Union[Tensor, Tuple[Tensor, Tensor]]]:
+        """Base mode: manual loop with cells."""
+        if self.batch_first:
+            input = input.transpose(0, 1)
+        seq_len, batch_size, _ = input.size()
+
+        if state is None:
+            state = self._default_initial_state(batch_size, input.device)
+        else:
+            state = self._prepare_state(state, batch_size, input.device)
+
+        if self.rnn_type == 'LSTM':
+            h0, c0 = state
+            h_list = torch.unbind(h0, dim=0)
+            c_list = torch.unbind(c0, dim=0)
+            h_states = list(h_list)
+            c_states = list(c_list)
+        else:
+            h_list = torch.unbind(state, dim=0)
+            h_states = list(h_list)
+            c_states = None
+
+        layer_input = input
+
+        for layer in range(self.num_layers):
+            dir_outputs = []
+            for direction in range(self.num_directions):
+                cell_idx = layer * self.num_directions + direction
+                cell = self.cells[cell_idx]
+
+                if self.rnn_type == 'LSTM':
+                    h = h_states[cell_idx]
+                    c = c_states[cell_idx]
+                    state_t = (h, c)
+                else:
+                    h = h_states[cell_idx]
+                    state_t = h
+
+                time_outputs = []
+                if direction == 0:  # forward
+                    for t in range(seq_len):
+                        x_t = layer_input[t]
+                        if self.rnn_type == 'LSTM':
+                            h, c = cell(x_t, state_t)
+                            state_t = (h, c)
+                        else:
+                            state_t = cell(x_t, state_t)
+                            h = state_t
+                        time_outputs.append(h)
+                    if self.rnn_type == 'LSTM':
+                        h_states[cell_idx] = h
+                        c_states[cell_idx] = c
+                    else:
+                        h_states[cell_idx] = h
+                    dir_outputs.append(time_outputs)
+                else:  # backward
+                    rev_outputs = []
+                    for t in range(seq_len - 1, -1, -1):
+                        x_t = layer_input[t]
+                        if self.rnn_type == 'LSTM':
+                            h, c = cell(x_t, state_t)
+                            state_t = (h, c)
+                        else:
+                            state_t = cell(x_t, state_t)
+                            h = state_t
+                        rev_outputs.append(h)
+                    time_outputs = rev_outputs[::-1]
+                    if self.rnn_type == 'LSTM':
+                        h_states[cell_idx] = h
+                        c_states[cell_idx] = c
+                    else:
+                        h_states[cell_idx] = h
+                    dir_outputs.append(time_outputs)
+
+            if self.bidirectional:
+                combined = [torch.cat([f, b], dim=-1) for f, b in zip(dir_outputs[0], dir_outputs[1])]
+            else:
+                combined = dir_outputs[0]
+
+            if self.dropout_layer is not None and layer < self.num_layers - 1:
+                combined = [self.dropout_layer(x) for x in combined]
+
+            layer_input = torch.stack(combined, dim=0)
+            if layer == self.num_layers - 1:
+                final_output = layer_input
+
+        if self.batch_first:
+            output = final_output.transpose(0, 1)
+        else:
+            output = final_output
+
+        if self.rnn_type == 'LSTM':
+            h_final = torch.stack(h_states, dim=0).view(self.num_layers * self.num_directions,
+                                                         batch_size, self.hidden_size)
+            c_final = torch.stack(c_states, dim=0).view(self.num_layers * self.num_directions,
+                                                         batch_size, self.hidden_size)
+            final_state = (h_final, c_final)
+        else:
+            h_final = torch.stack(h_states, dim=0).view(self.num_layers * self.num_directions,
+                                                         batch_size, self.hidden_size)
+            final_state = h_final
+
+        return output, final_state
+
+    def _forward_impl_legacy(self, input: Tensor, state: Optional[Union[Tensor, Tuple[Tensor, Tensor]]] = None):
+        """Legacy mode: augment input, delegate to native RNN."""
+        aug_input = _augment_input(input, self.funcs)
+        return self.rnn(aug_input, state)
+
+    def forward(self, input: Union[Tensor, PackedSequence],
+                state: Optional[Union[Tensor, Tuple[Tensor, Tensor]]] = None):
+        if self.mode == 'legacy':
+            if isinstance(input, PackedSequence):
+                input_unpacked, lengths = pad_packed_sequence(input, batch_first=self.batch_first)
+                output, final_state = self._forward_impl_legacy(input_unpacked, state)
+                output_packed = pack_padded_sequence(output, lengths.cpu(),
+                                                      batch_first=self.batch_first,
+                                                      enforce_sorted=False)
+                return output_packed, final_state
+            else:
+                return self._forward_impl_legacy(input, state)
+        else:
+            if isinstance(input, PackedSequence):
+                input_unpacked, lengths = pad_packed_sequence(input, batch_first=self.batch_first)
+                output, final_state = self._forward_impl_base(input_unpacked, state)
+                output_packed = pack_padded_sequence(output, lengths.cpu(),
+                                                      batch_first=self.batch_first,
+                                                      enforce_sorted=False)
+                return output_packed, final_state
+            else:
+                return self._forward_impl_base(input, state)
 
     def extra_repr(self) -> str:
         s = f'input_size={self.original_input_size}, hidden_size={self.hidden_size}'
@@ -211,208 +361,133 @@ class TNRNNBase(nn.Module):
         if self.bidirectional is not False:
             s += f', bidirectional={self.bidirectional}'
         if self.symbolic_expression != 'x':
-            s += f', symbolic_expression={self.symbolic_expression}'
+            s += f', symbolic_expression="{self.symbolic_expression}"'
+        if self.mode != 'base':
+            s += f', mode="{self.mode}"'
         return s
 
     def __getstate__(self):
-        # Remove compiled lambdas for pickling
+        # Remove non-picklable attributes
         state = self.__dict__.copy()
-        state.pop('funcs', None)
+        if self.mode == 'legacy':
+            state.pop('funcs', None)
         return state
 
     def __setstate__(self, state):
         self.__dict__.update(state)
-        # Re‑build funcs from the expression
-        self.funcs = _parse_expression(self.symbolic_expression)
+        if self.mode == 'legacy':
+            self.funcs = _parse_expression(self.symbolic_expression)
 
 
-# ---------- Concrete RNN classes ----------
+# ========== Concrete RNN classes ==========
 
-class TNRNN(TNRNNBase):
-    """
-    A multi‑layer RNN with custom neuron aggregation.
-
-    This is the equivalent of :class:`torch.nn.RNN` where the input is first
-    augmented by basis functions defined in `symbolic_expression`.
-
-    Args:
-        input_size (int): Number of input features.
-        hidden_size (int): Number of hidden features.
-        num_layers (int): Number of recurrent layers. Default: 1.
-        nonlinearity (str): The non‑linearity to use: 'tanh' or 'relu'. Default: 'tanh'.
-        bias (bool): If False, no bias weights are used. Default: True.
-        batch_first (bool): If True, input/output shape is (batch, seq, feature). Default: False.
-        dropout (float): Dropout probability. Default: 0.0.
-        bidirectional (bool): If True, becomes bidirectional. Default: False.
-        symbolic_expression (str): Basis function expression. Default: 'x'.
-        device (torch.device, optional): Device for parameters.
-        dtype (torch.dtype, optional): Data type for parameters.
-    """
+class TNRNN(_TNRNNBase):
     def __init__(self, input_size: int, hidden_size: int, num_layers: int = 1,
                  nonlinearity: str = 'tanh', bias: bool = True, batch_first: bool = False,
                  dropout: float = 0.0, bidirectional: bool = False,
-                 symbolic_expression: str = 'x', device=None, dtype=None):
-        super().__init__('RNN', input_size, hidden_size, num_layers, bias,
-                         batch_first, dropout, bidirectional, symbolic_expression,
-                         device, dtype)
-        self.rnn.nonlinearity = nonlinearity
+                 symbolic_expression: str = 'x', device=None, dtype=None,
+                 mode: str = 'base'):
+        self.nonlinearity = nonlinearity
+        def cell_factory(in_size, h_size, b, sym_expr, dev, dtyp):
+            return TNRNNCell(in_size, h_size, bias=b, nonlinearity=nonlinearity,
+                             symbolic_expression=sym_expr, device=dev, dtype=dtyp, mode=mode)
+        super().__init__(cell_factory, mode, 'RNN', input_size, hidden_size, num_layers,
+                         bias, batch_first, dropout, bidirectional,
+                         symbolic_expression, device, dtype)
 
 
-class TNLSTM(TNRNNBase):
-    """
-    A multi‑layer LSTM with custom neuron aggregation.
-
-    This is the equivalent of :class:`torch.nn.LSTM` where the input is first
-    augmented by basis functions defined in `symbolic_expression`.
-
-    Args:
-        input_size (int): Number of input features.
-        hidden_size (int): Number of hidden features.
-        num_layers (int): Number of recurrent layers. Default: 1.
-        bias (bool): If False, no bias weights are used. Default: True.
-        batch_first (bool): If True, input/output shape is (batch, seq, feature). Default: False.
-        dropout (float): Dropout probability. Default: 0.0.
-        bidirectional (bool): If True, becomes bidirectional. Default: False.
-        symbolic_expression (str): Basis function expression. Default: 'x'.
-        device (torch.device, optional): Device for parameters.
-        dtype (torch.dtype, optional): Data type for parameters.
-    """
+class TNLSTM(_TNRNNBase):
     def __init__(self, input_size: int, hidden_size: int, num_layers: int = 1,
                  bias: bool = True, batch_first: bool = False,
                  dropout: float = 0.0, bidirectional: bool = False,
-                 symbolic_expression: str = 'x', device=None, dtype=None):
-        super().__init__('LSTM', input_size, hidden_size, num_layers, bias,
-                         batch_first, dropout, bidirectional, symbolic_expression,
-                         device, dtype)
+                 symbolic_expression: str = 'x', device=None, dtype=None,
+                 mode: str = 'base'):
+        def cell_factory(in_size, h_size, b, sym_expr, dev, dtyp):
+            return TNLSTMCell(in_size, h_size, bias=b,
+                              symbolic_expression=sym_expr, device=dev, dtype=dtyp, mode=mode)
+        super().__init__(cell_factory, mode, 'LSTM', input_size, hidden_size, num_layers,
+                         bias, batch_first, dropout, bidirectional,
+                         symbolic_expression, device, dtype)
 
 
-class TNGRU(TNRNNBase):
-    """
-    A multi‑layer GRU with custom neuron aggregation.
-
-    This is the equivalent of :class:`torch.nn.GRU` where the input is first
-    augmented by basis functions defined in `symbolic_expression`.
-
-    Args:
-        input_size (int): Number of input features.
-        hidden_size (int): Number of hidden features.
-        num_layers (int): Number of recurrent layers. Default: 1.
-        bias (bool): If False, no bias weights are used. Default: True.
-        batch_first (bool): If True, input/output shape is (batch, seq, feature). Default: False.
-        dropout (float): Dropout probability. Default: 0.0.
-        bidirectional (bool): If True, becomes bidirectional. Default: False.
-        symbolic_expression (str): Basis function expression. Default: 'x'.
-        device (torch.device, optional): Device for parameters.
-        dtype (torch.dtype, optional): Data type for parameters.
-    """
+class TNGRU(_TNRNNBase):
     def __init__(self, input_size: int, hidden_size: int, num_layers: int = 1,
                  bias: bool = True, batch_first: bool = False,
                  dropout: float = 0.0, bidirectional: bool = False,
-                 symbolic_expression: str = 'x', device=None, dtype=None):
-        super().__init__('GRU', input_size, hidden_size, num_layers, bias,
-                         batch_first, dropout, bidirectional, symbolic_expression,
-                         device, dtype)
+                 symbolic_expression: str = 'x', device=None, dtype=None,
+                 mode: str = 'base'):
+        def cell_factory(in_size, h_size, b, sym_expr, dev, dtyp):
+            return TNGRUCell(in_size, h_size, bias=b,
+                             symbolic_expression=sym_expr, device=dev, dtype=dtyp, mode=mode)
+        super().__init__(cell_factory, mode, 'GRU', input_size, hidden_size, num_layers,
+                         bias, batch_first, dropout, bidirectional,
+                         symbolic_expression, device, dtype)
 
 
-# ---------- Cell versions (using TNLinear for per‑time‑step computation) ----------
+# ---------- Public alias for backward compatibility ----------
+class TNRNNBase(_TNRNNBase):
+    pass
+
+
+# ========== Cell classes ==========
 
 class TNRNNCellBase(nn.Module):
-    """
-    Base class for RNN cells with custom neuron aggregation.
-
-    This class uses :class:`TNLinear` for both input‑to‑hidden and
-    hidden‑to‑hidden projections, applying the basis functions from the
-    symbolic expression inside each linear layer. It is intended to be
-    subclassed by specific cell types.
-
-    Args:
-        input_size (int): Number of input features.
-        hidden_size (int): Number of hidden features.
-        bias (bool): If True, adds a bias to both linear layers.
-        symbolic_expression (str): Basis function expression. Default: 'x'.
-        num_chunks (int): Number of chunks to split the output into (e.g., 4 for LSTM).
-        device (torch.device, optional): Device for parameters.
-        dtype (torch.dtype, optional): Data type for parameters.
-    """
-    __constants__ = ['input_size', 'hidden_size', 'bias', 'symbolic_expression']
+    __constants__ = ['input_size', 'hidden_size', 'bias', 'symbolic_expression', 'mode']
 
     def __init__(self, input_size: int, hidden_size: int, bias: bool,
                  symbolic_expression: str = 'x', num_chunks: int = 1,
-                 device=None, dtype=None):
+                 device=None, dtype=None, mode: str = 'base'):
         super().__init__()
         self.input_size = input_size
         self.hidden_size = hidden_size
         self.bias = bias
         self.symbolic_expression = symbolic_expression
         self.num_chunks = num_chunks
+        self.mode = mode.lower()
 
-        # Input‑to‑hidden linear layer
         self.ih = TNLinear(
             in_features=input_size,
             out_features=num_chunks * hidden_size,
             symbolic_expression=symbolic_expression,
             bias=bias,
             device=device,
-            dtype=dtype
+            dtype=dtype,
+            mode=mode
         )
-        # Hidden‑to‑hidden linear layer
         self.hh = TNLinear(
             in_features=hidden_size,
             out_features=num_chunks * hidden_size,
             symbolic_expression=symbolic_expression,
             bias=bias,
             device=device,
-            dtype=dtype
+            dtype=dtype,
+            mode=mode
         )
         self.reset_parameters()
 
     def reset_parameters(self) -> None:
-        """Parameter initialisation (handled internally by TNLinear)."""
         pass
 
     def extra_repr(self) -> str:
-        s = '{input_size}, {hidden_size}'
+        s = f'{self.input_size}, {self.hidden_size}'
         if self.bias is not True:
-            s += ', bias={bias}'
+            s += f', bias={self.bias}'
         if self.symbolic_expression != 'x':
-            s += ', symbolic_expression={symbolic_expression}'
-        return s.format(**self.__dict__)
+            s += f', symbolic_expression={self.symbolic_expression}'
+        if self.mode != 'base':
+            s += f', mode={self.mode}'
+        return s
 
 
 class TNRNNCell(TNRNNCellBase):
-    """
-    An RNN cell with custom neuron aggregation.
-
-    This is the equivalent of :class:`torch.nn.RNNCell` where both linear
-    transformations use :class:`TNLinear` with the given symbolic expression.
-
-    Args:
-        input_size (int): Number of input features.
-        hidden_size (int): Number of hidden features.
-        bias (bool): If True, adds a bias. Default: True.
-        nonlinearity (str): 'tanh' or 'relu'. Default: 'tanh'.
-        symbolic_expression (str): Basis function expression. Default: 'x'.
-        device (torch.device, optional): Device for parameters.
-        dtype (torch.dtype, optional): Data type for parameters.
-    """
     def __init__(self, input_size: int, hidden_size: int, bias: bool = True,
                  nonlinearity: str = 'tanh', symbolic_expression: str = 'x',
-                 device=None, dtype=None):
+                 device=None, dtype=None, mode: str = 'base'):
         super().__init__(input_size, hidden_size, bias, symbolic_expression,
-                         num_chunks=1, device=device, dtype=dtype)
+                         num_chunks=1, device=device, dtype=dtype, mode=mode)
         self.nonlinearity = nonlinearity
 
     def forward(self, input: Tensor, hx: Optional[Tensor] = None) -> Tensor:
-        """
-        Forward pass of the RNN cell.
-
-        Args:
-            input (Tensor): Input tensor of shape (batch, input_size) or (input_size,).
-            hx (Tensor, optional): Initial hidden state. If not provided, zeros.
-
-        Returns:
-            Tensor: Next hidden state.
-        """
         is_batched = input.dim() == 2
         if not is_batched:
             input = input.unsqueeze(0)
@@ -439,37 +514,13 @@ class TNRNNCell(TNRNNCellBase):
 
 
 class TNLSTMCell(TNRNNCellBase):
-    """
-    An LSTM cell with custom neuron aggregation.
-
-    This is the equivalent of :class:`torch.nn.LSTMCell` where both linear
-    transformations use :class:`TNLinear` with the given symbolic expression.
-
-    Args:
-        input_size (int): Number of input features.
-        hidden_size (int): Number of hidden features.
-        bias (bool): If True, adds a bias. Default: True.
-        symbolic_expression (str): Basis function expression. Default: 'x'.
-        device (torch.device, optional): Device for parameters.
-        dtype (torch.dtype, optional): Data type for parameters.
-    """
     def __init__(self, input_size: int, hidden_size: int, bias: bool = True,
-                 symbolic_expression: str = 'x', device=None, dtype=None):
+                 symbolic_expression: str = 'x', device=None, dtype=None,
+                 mode: str = 'base'):
         super().__init__(input_size, hidden_size, bias, symbolic_expression,
-                         num_chunks=4, device=device, dtype=dtype)
+                         num_chunks=4, device=device, dtype=dtype, mode=mode)
 
     def forward(self, input: Tensor, hx: Optional[Tuple[Tensor, Tensor]] = None) -> Tuple[Tensor, Tensor]:
-        """
-        Forward pass of the LSTM cell.
-
-        Args:
-            input (Tensor): Input tensor of shape (batch, input_size) or (input_size,).
-            hx (Tuple[Tensor, Tensor], optional): Tuple of (hidden, cell) states.
-                If not provided, both are zeros.
-
-        Returns:
-            Tuple[Tensor, Tensor]: (new_hidden, new_cell).
-        """
         is_batched = input.dim() == 2
         if not is_batched:
             input = input.unsqueeze(0)
@@ -505,36 +556,13 @@ class TNLSTMCell(TNRNNCellBase):
 
 
 class TNGRUCell(TNRNNCellBase):
-    """
-    A GRU cell with custom neuron aggregation.
-
-    This is the equivalent of :class:`torch.nn.GRUCell` where both linear
-    transformations use :class:`TNLinear` with the given symbolic expression.
-
-    Args:
-        input_size (int): Number of input features.
-        hidden_size (int): Number of hidden features.
-        bias (bool): If True, adds a bias. Default: True.
-        symbolic_expression (str): Basis function expression. Default: 'x'.
-        device (torch.device, optional): Device for parameters.
-        dtype (torch.dtype, optional): Data type for parameters.
-    """
     def __init__(self, input_size: int, hidden_size: int, bias: bool = True,
-                 symbolic_expression: str = 'x', device=None, dtype=None):
+                 symbolic_expression: str = 'x', device=None, dtype=None,
+                 mode: str = 'base'):
         super().__init__(input_size, hidden_size, bias, symbolic_expression,
-                         num_chunks=3, device=device, dtype=dtype)
+                         num_chunks=3, device=device, dtype=dtype, mode=mode)
 
     def forward(self, input: Tensor, hx: Optional[Tensor] = None) -> Tensor:
-        """
-        Forward pass of the GRU cell.
-
-        Args:
-            input (Tensor): Input tensor of shape (batch, input_size) or (input_size,).
-            hx (Tensor, optional): Initial hidden state. If not provided, zeros.
-
-        Returns:
-            Tensor: Next hidden state.
-        """
         is_batched = input.dim() == 2
         if not is_batched:
             input = input.unsqueeze(0)

--- a/tnlearn/modules/TNtransformer.py
+++ b/tnlearn/modules/TNtransformer.py
@@ -2,10 +2,14 @@
 Transformer with TNLinear for custom neuron aggregation (symbolic expression)
 
 This module provides Transformer components that replace the standard linear layers
-with TNLinear, allowing user-defined base functions (e.g., 'x + torch.sin(x)')
+with TNLinear, allowing user-defined base functions (e.g., 'x + x ** 2')
 inside the feed-forward networks and other linear projections.
 
-Based on PyTorch's torch.nn.modules.transformer.
+Two modes are available:
+- base (default): Uses the standard TNLinear with SymPy/InnerProduct (no .weight).
+- legacy: Uses the eval-based TNLinear implementation (has .weight).
+
+Copyright (c) 2026 Tieyun LI. All Rights Reserved.
 """
 
 import copy
@@ -101,6 +105,7 @@ class TNTransformerEncoderLayer(Module):
         norm_first: if True, layer norm before attention/ff, else after (default=False).
         bias: if False, linear and LayerNorm layers have no bias (default=True).
         symbolic_expression: symbolic expression for TNLinear (default='x').
+        mode: 'base' or 'legacy' (default='base').
         device, dtype: factory kwargs.
     """
     __constants__ = ['norm_first']
@@ -117,22 +122,25 @@ class TNTransformerEncoderLayer(Module):
             norm_first: bool = False,
             bias: bool = True,
             symbolic_expression: str = 'x',
+            mode: str = 'base',
             device=None,
             dtype=None
     ) -> None:
         factory_kwargs = {'device': device, 'dtype': dtype}
         super().__init__()
+        self.mode = mode.lower()
         self.self_attn = MultiheadAttention(
             d_model, nhead, dropout=dropout,
             bias=bias, batch_first=batch_first,
             **factory_kwargs
         )
 
-        # Replace Linear with TNLinear
+        # Replace Linear with TNLinear, passing mode
         self.linear1 = TNLinear(
             d_model, dim_feedforward,
             symbolic_expression=symbolic_expression,
             bias=bias,
+            mode=self.mode,
             **factory_kwargs
         )
         self.dropout = Dropout(dropout)
@@ -140,6 +148,7 @@ class TNTransformerEncoderLayer(Module):
             dim_feedforward, d_model,
             symbolic_expression=symbolic_expression,
             bias=bias,
+            mode=self.mode,
             **factory_kwargs
         )
 
@@ -191,7 +200,10 @@ class TNTransformerEncoderLayer(Module):
 
         # fast path (same logic as original, using self.attn etc.)
         why_not_sparsity_fast_path = ''
-        if not src.dim() == 3:
+        # ----- Disable fast path for base mode (no .weight attribute) -----
+        if self.mode == 'base':
+            why_not_sparsity_fast_path = "base mode TNLinear has no .weight attribute"
+        elif not src.dim() == 3:
             why_not_sparsity_fast_path = "input not batched; expected src.dim() of 3"
         elif self.training:
             why_not_sparsity_fast_path = "training is enabled"
@@ -282,7 +294,22 @@ class TNTransformerEncoderLayer(Module):
 
 
 class TNTransformerDecoderLayer(Module):
-    r"""TransformerDecoderLayer with TNLinear."""
+    r"""TransformerDecoderLayer with TNLinear.
+
+    Args:
+        d_model: number of expected features (required).
+        nhead: number of heads (required).
+        dim_feedforward: dimension of feedforward network (default=2048).
+        dropout: dropout value (default=0.1).
+        activation: activation function (default=relu).
+        layer_norm_eps: eps for LayerNorm (default=1e-5).
+        batch_first: if True, input/output shape (batch, seq, feature) (default=False).
+        norm_first: if True, layer norm before attention/ff, else after (default=False).
+        bias: if False, linear and LayerNorm layers have no bias (default=True).
+        symbolic_expression: symbolic expression for TNLinear (default='x').
+        mode: 'base' or 'legacy' (default='base').
+        device, dtype: factory kwargs.
+    """
     __constants__ = ['norm_first']
 
     def __init__(
@@ -297,11 +324,13 @@ class TNTransformerDecoderLayer(Module):
             norm_first: bool = False,
             bias: bool = True,
             symbolic_expression: str = 'x',
+            mode: str = 'base',
             device=None,
             dtype=None
     ) -> None:
         factory_kwargs = {'device': device, 'dtype': dtype}
         super().__init__()
+        self.mode = mode.lower()
         self.self_attn = MultiheadAttention(
             d_model, nhead, dropout=dropout,
             batch_first=batch_first, bias=bias,
@@ -317,6 +346,7 @@ class TNTransformerDecoderLayer(Module):
             d_model, dim_feedforward,
             symbolic_expression=symbolic_expression,
             bias=bias,
+            mode=self.mode,
             **factory_kwargs
         )
         self.dropout = Dropout(dropout)
@@ -324,6 +354,7 @@ class TNTransformerDecoderLayer(Module):
             dim_feedforward, d_model,
             symbolic_expression=symbolic_expression,
             bias=bias,
+            mode=self.mode,
             **factory_kwargs
         )
 
@@ -411,6 +442,9 @@ class TNTransformerEncoder(Module):
         self.use_nested_tensor = enable_nested_tensor
         self.mask_check = mask_check
 
+        # Store mode from the encoder layer for fast path control
+        self.mode = encoder_layer.mode
+
         # check fast path compatibility (same as original)
         enc_layer = "encoder_layer"
         why_not_sparsity_fast_path = ''
@@ -465,7 +499,10 @@ class TNTransformerEncoder(Module):
         why_not_sparsity_fast_path = ''
         batch_first = first_layer.self_attn.batch_first
 
-        if not hasattr(self, "use_nested_tensor"):
+        # ----- Disable fast path for base mode (no .weight attribute) -----
+        if self.mode == 'base':
+            why_not_sparsity_fast_path = "base mode TNLinear has no .weight attribute"
+        elif not hasattr(self, "use_nested_tensor"):
             why_not_sparsity_fast_path = "use_nested_tensor attribute not present"
         elif not self.use_nested_tensor:
             why_not_sparsity_fast_path = "self.use_nested_tensor was not True"
@@ -591,6 +628,7 @@ class TNTransformer(Module):
         norm_first: if True, layer norm before attention/ff, else after (default=False).
         bias: if False, linear and LayerNorm layers have no bias (default=True).
         symbolic_expression: symbolic expression for TNLinear (default='x').
+        mode: 'base' or 'legacy' (default='base').
         device, dtype: factory kwargs.
     """
     def __init__(
@@ -609,6 +647,7 @@ class TNTransformer(Module):
             norm_first: bool = False,
             bias: bool = True,
             symbolic_expression: str = 'x',
+            mode: str = 'base',
             device=None,
             dtype=None
     ) -> None:
@@ -622,7 +661,7 @@ class TNTransformer(Module):
             encoder_layer = TNTransformerEncoderLayer(
                 d_model, nhead, dim_feedforward, dropout,
                 activation, layer_norm_eps, batch_first, norm_first,
-                bias, symbolic_expression, **factory_kwargs
+                bias, symbolic_expression, mode, **factory_kwargs
             )
             encoder_norm = LayerNorm(d_model, eps=layer_norm_eps, bias=bias, **factory_kwargs)
             self.encoder = TNTransformerEncoder(encoder_layer, num_encoder_layers, encoder_norm)
@@ -633,7 +672,7 @@ class TNTransformer(Module):
             decoder_layer = TNTransformerDecoderLayer(
                 d_model, nhead, dim_feedforward, dropout,
                 activation, layer_norm_eps, batch_first, norm_first,
-                bias, symbolic_expression, **factory_kwargs
+                bias, symbolic_expression, mode, **factory_kwargs
             )
             decoder_norm = LayerNorm(d_model, eps=layer_norm_eps, bias=bias, **factory_kwargs)
             self.decoder = TNTransformerDecoder(decoder_layer, num_decoder_layers, decoder_norm)

--- a/tnlearn/operator/inner_product.py
+++ b/tnlearn/operator/inner_product.py
@@ -1,0 +1,492 @@
+# operator/inner_product.py
+from sympy import Expr, Add, Mul, sympify, symbols, Symbol, Number, Pow, sin, cos, exp
+import re
+import numpy as np
+import torch
+
+class InnerProduct(Expr):
+    def __new__(cls, left, right, **kwargs):
+        left = sympify(left)
+        right = sympify(right)
+        obj = Expr.__new__(cls, left, right, **kwargs)
+        return obj
+
+    @property
+    def left(self):
+        return self.args[0]
+
+    @property
+    def right(self):
+        return self.args[1]
+
+    def __str__(self):
+        return f"InnerProduct({self.left}, {self.right})"
+
+    def _sympystr(self, printer):
+        return f"InnerProduct({printer.doprint(self.left)}, {printer.doprint(self.right)})"
+
+    def __repr__(self):
+        return f"<{self.left}, {self.right}>"
+
+    def _eval_expand_basic(self, **hints):
+        left, right = self.left, self.right
+        if isinstance(left, Add) and isinstance(right, Add):
+            return Add(*[InnerProduct(lterm, rterm)
+                         for lterm in left.args for rterm in right.args])
+        if isinstance(left, Add):
+            return Add(*[InnerProduct(term, right) for term in left.args])
+        if isinstance(right, Add):
+            return Add(*[InnerProduct(left, term) for term in right.args])
+        return self
+
+    def _eval_simplify(self, **kwargs):
+        left = _simplify_expr(self.left)
+        right = _simplify_expr(self.right)
+        if left == 0 or right == 0:
+            return 0
+        expanded = InnerProduct(left, right)._eval_expand_basic(**kwargs)
+        if expanded != InnerProduct(left, right):
+            return _simplify_expr(expanded, **kwargs)
+        return InnerProduct(left, right)
+
+
+def _simplify_expr(expr, **kwargs):
+    """
+    Recursively simplify InnerProduct and arithmetic expressions.
+    Also extracts leading minus signs from InnerProduct arguments.
+    """
+    from sympy import Mul, S, Add
+    if isinstance(expr, InnerProduct):
+        left = _simplify_expr(expr.left, **kwargs)
+        right = _simplify_expr(expr.right, **kwargs)
+        if left == 0 or right == 0:
+            return 0
+
+        def extract_sign(e):
+            """Extract sign from expression: returns (sign, core) where sign is 1 or -1."""
+            if e.is_Mul:
+                coeff, rest = e.as_coeff_Mul()
+                if coeff < 0:
+                    # Extract negative sign, core becomes the positive coefficient part
+                    return -1, Mul(-coeff, rest)
+                else:
+                    return 1, e
+            elif e.is_Number and e < 0:
+                return -1, -e
+            else:
+                return 1, e
+
+        sign_left, core_left = extract_sign(left)
+        sign_right, core_right = extract_sign(right)
+        total_sign = sign_left * sign_right  # 1 or -1
+
+        inner = InnerProduct(core_left, core_right)
+        expanded = inner._eval_expand_basic(**kwargs)
+        if expanded != inner:
+            result = _simplify_expr(expanded, **kwargs)
+        else:
+            result = inner
+
+        if total_sign == -1:
+            return Mul(-1, result)
+        else:
+            return result
+
+    elif isinstance(expr, Add):
+        new_args = [_simplify_expr(arg, **kwargs) for arg in expr.args]
+        new_args = [a for a in new_args if a != 0]
+        return Add(*new_args) if new_args else 0
+
+    elif isinstance(expr, Mul):
+        new_args = [_simplify_expr(arg, **kwargs) for arg in expr.args]
+        if any(a == 0 for a in new_args):
+            return 0
+        return Mul(*new_args)
+
+    else:
+        if hasattr(expr, 'args') and expr.args:
+            new_args = [_simplify_expr(arg, **kwargs) for arg in expr.args]
+            return expr.func(*new_args)
+        return expr
+
+
+def convert_pretty_to_innerproduct(expr_str):
+    pattern = r'<([^<>]+)>'
+    def repl(match):
+        inner = match.group(1).strip()
+        return f"InnerProduct({inner})"
+    while '<' in expr_str:
+        expr_str = re.sub(pattern, repl, expr_str)
+    return expr_str
+
+def convert_innerproduct_to_pretty(expr_str: str) -> str:
+    """
+    Convert InnerProduct(...) and IP(...) to pretty <...> format.
+    
+    Example:
+        "InnerProduct(w, x**2) + IP(c, x)" -> "<w, x**2> + <c, x>"
+    """
+    expr_str = re.sub(r'\bIP\s*\(', 'InnerProduct(', expr_str)
+    # replace InnerProduct(...) with <...>，aavailable for <<*,*>,*>
+    pattern = r'InnerProduct\s*\(([^()]*)\)'
+    while re.search(pattern, expr_str):
+        expr_str = re.sub(pattern, r'<\1>', expr_str)
+    return expr_str
+
+
+def is_inner_product(expr):
+    return isinstance(expr, InnerProduct)
+
+
+def replace_numbers(expr, counter, in_exponent=False):
+    if isinstance(expr, Symbol):
+        return expr
+    if expr.is_Number:
+        if not in_exponent:
+            w = symbols('w%d' % counter['w'])
+            counter['w'] += 1
+            return w
+        return expr
+    elif expr.is_Pow:
+        base, exp = expr.args
+        return Pow(replace_numbers(base, counter, False),
+                   replace_numbers(exp, counter, True))
+    elif expr.is_Mul:
+        return Mul(*[replace_numbers(arg, counter, in_exponent) for arg in expr.args])
+    elif expr.is_Add:
+        return Add(*[replace_numbers(arg, counter, in_exponent) for arg in expr.args])
+    elif is_inner_product(expr):
+        a1, a2 = expr.args
+        return InnerProduct(replace_numbers(a1, counter, False),
+                            replace_numbers(a2, counter, False))
+    elif hasattr(expr, 'args') and not isinstance(expr, (Symbol, int, float, Number)):
+        return expr.func(*[replace_numbers(arg, counter, False) for arg in expr.args])
+    else:
+        return expr
+
+
+def parameterize_term(term, counter, include_bias=False):
+    if term.is_number:
+        if include_bias:
+            b = symbols('b%d' % counter['b'])
+            counter['b'] += 1
+            return b
+        else:
+            return 0
+    if is_inner_product(term):
+        a1, a2 = term.args
+        old_w = counter['w']
+        new_a1 = replace_numbers(a1, counter, False)
+        new_a2 = replace_numbers(a2, counter, False)
+        new_ip = InnerProduct(new_a1, new_a2)
+        if counter['w'] == old_w:
+            c = symbols('c%d' % counter['c'])
+            counter['c'] += 1
+            return Mul(c, new_ip)
+        return new_ip
+    if isinstance(term, Mul):
+        inner_products = []
+        non_inner = []
+        created_param = False
+        for factor in term.args:
+            if factor.is_number:
+                continue
+            elif is_inner_product(factor):
+                a1, a2 = factor.args
+                old_w = counter['w']
+                new_a1 = replace_numbers(a1, counter, False)
+                new_a2 = replace_numbers(a2, counter, False)
+                if counter['w'] > old_w:
+                    created_param = True
+                inner_products.append(InnerProduct(new_a1, new_a2))
+            else:
+                non_inner.append(factor)
+        if non_inner:
+            merged = Mul(*non_inner)
+            old_w = counter['w']
+            merged = replace_numbers(merged, counter, False)
+            if counter['w'] > old_w:
+                created_param = True
+            w = symbols('w%d' % counter['w'])
+            counter['w'] += 1
+            created_param = True
+            inner_products.append(InnerProduct(w, merged))
+        if not inner_products:
+            return 1
+        result = Mul(*inner_products) if len(inner_products) > 1 else inner_products[0]
+        if not created_param:
+            c = symbols('c%d' % counter['c'])
+            counter['c'] += 1
+            result = Mul(c, result)
+        return result
+    new_expr = replace_numbers(term, counter, False)
+    w = symbols('w%d' % counter['w'])
+    counter['w'] += 1
+    return InnerProduct(w, new_expr)
+
+
+def parameterize_expression(expr, include_bias=False):
+    if isinstance(expr, Add):
+        terms = list(expr.args)
+    else:
+        terms = [expr]
+    counter = {'w': 1, 'c': 1, 'b': 1}
+    new_terms = []
+    for t in terms:
+        pt = parameterize_term(t, counter, include_bias)
+        if pt != 0:
+            new_terms.append(pt)
+    if not new_terms:
+        return 0
+    return Add(*new_terms) if len(new_terms) > 1 else new_terms[0]
+
+
+def inner_product(a, b, N=None):
+    is_torch = isinstance(a, torch.Tensor) or isinstance(b, torch.Tensor)
+    if is_torch:
+        a = torch.as_tensor(a) if not isinstance(a, torch.Tensor) else a
+        b = torch.as_tensor(b) if not isinstance(b, torch.Tensor) else b
+        if N is None:
+            if a.ndim >= 1:
+                N = a.shape[0]
+            elif b.ndim >= 1:
+                N = b.shape[0]
+            else:
+                N = 1
+        if a.ndim == 0:
+            a = a.expand(N, 1)
+        if b.ndim == 0:
+            b = b.expand(N, 1)
+        if a.ndim == 1:
+            if a.shape[0] == N:
+                a = a.unsqueeze(1)
+            else:
+                a = a.expand(N, -1)
+        if b.ndim == 1:
+            if b.shape[0] == N:
+                b = b.unsqueeze(1)
+            else:
+                b = b.expand(N, -1)
+        if a.ndim == 2 and b.ndim == 2:
+            if a.shape[1] != b.shape[1]:
+                if a.shape[1] == 1:
+                    a = a.expand(-1, b.shape[1])
+                elif b.shape[1] == 1:
+                    b = b.expand(-1, a.shape[1])
+                else:
+                    raise ValueError(f"Dim mismatch: {a.shape[1]} vs {b.shape[1]}")
+            return torch.sum(a * b, dim=-1, keepdim=True)
+        else:
+            raise ValueError(f"Unsupported ndim: a={a.ndim}, b={b.ndim}")
+    else:
+        a = np.asarray(a)
+        b = np.asarray(b)
+        if N is None:
+            if a.ndim >= 1:
+                N = a.shape[0]
+            elif b.ndim >= 1:
+                N = b.shape[0]
+            else:
+                N = 1
+        if a.ndim == 0:
+            a = np.full((N, 1), a)
+        if b.ndim == 0:
+            b = np.full((N, 1), b)
+        if a.ndim == 1:
+            if a.shape[0] == N:
+                a = a[:, np.newaxis]
+            else:
+                a = np.broadcast_to(a, (N, a.shape[0]))
+        if b.ndim == 1:
+            if b.shape[0] == N:
+                b = b[:, np.newaxis]
+            else:
+                b = np.broadcast_to(b, (N, b.shape[0]))
+        if a.ndim == 2 and b.ndim == 2:
+            if a.shape[1] != b.shape[1]:
+                if a.shape[1] == 1:
+                    a = np.broadcast_to(a, (N, b.shape[1]))
+                elif b.shape[1] == 1:
+                    b = np.broadcast_to(b, (N, a.shape[1]))
+                else:
+                    raise ValueError(f"Dim mismatch: {a.shape[1]} vs {b.shape[1]}")
+            return np.sum(a * b, axis=-1, keepdims=True)
+        else:
+            raise ValueError(f"Unsupported ndim: a={a.ndim}, b={b.ndim}")
+
+
+def eval_sympy_expr(expr, subs):
+    if expr.is_Number:
+        device = next(iter(subs.values())).device
+        return torch.tensor(float(expr), device=device)
+    if expr.is_Symbol:
+        return subs[expr]
+    if expr.is_Add:
+        terms = [eval_sympy_expr(arg, subs) for arg in expr.args]
+        result = terms[0]
+        for t in terms[1:]:
+            result = result + t
+        return result
+    if expr.is_Mul:
+        result = eval_sympy_expr(expr.args[0], subs)
+        for arg in expr.args[1:]:
+            result = result * eval_sympy_expr(arg, subs)
+        return result
+    if expr.is_Pow:
+        return eval_sympy_expr(expr.base, subs) ** eval_sympy_expr(expr.exp, subs)
+    if expr.func.__name__ == 'sin':
+        return torch.sin(eval_sympy_expr(expr.args[0], subs))
+    if expr.func.__name__ == 'cos':
+        return torch.cos(eval_sympy_expr(expr.args[0], subs))
+    if expr.func.__name__ == 'exp':
+        return torch.exp(eval_sympy_expr(expr.args[0], subs))
+    if is_inner_product(expr):
+        a = eval_sympy_expr(expr.args[0], subs)
+        b = eval_sympy_expr(expr.args[1], subs)
+        return (a * b).sum(dim=-1, keepdim=True)
+    raise NotImplementedError(f"Unsupported expression: {expr}")
+
+
+def evaluate_expression(expr, x_tensor, param_dict, out_dim):
+    batch = x_tensor.size(0)
+    results = []
+    x_sym = symbols('x')
+    for j in range(out_dim):
+        subs = {x_sym: x_tensor}
+        for sym_str, param in param_dict.items():
+            sym_obj = symbols(sym_str)
+            if param.dim() == 2 and param.size(0) == out_dim:
+                subs[sym_obj] = param[j:j+1]
+            elif param.dim() == 2 and param.size(0) == out_dim and param.size(1) == 1:
+                subs[sym_obj] = param[j:j+1]
+            elif param.dim() == 1 and param.size(0) == out_dim:
+                subs[sym_obj] = param[j:j+1]
+            else:
+                subs[sym_obj] = param
+        val = eval_sympy_expr(expr, subs)
+        if val.dim() == 1:
+            val = val.unsqueeze(-1)
+        results.append(val)
+    return torch.cat(results, dim=1)
+
+
+def neuronseek_config_to_string(config: dict) -> str:
+    """
+    Convert a NeuronSeek configuration dictionary to a human-readable mathematical expression string.
+
+    The expression consists of a polynomial stream, an interaction stream, and an optional periodic stream.
+    Pure terms are represented as <w_i, x> for k=1 and <w_i, x**k> for k>1.
+    Interaction terms are represented as products of linear inner products <w_j, x>
+    for each interaction order m in `interact_indices`, using a rank-1 CP decomposition.
+    If `periodic` is True, a term <w_i, sin(x)> is appended.
+
+    This function performs input validation and gracefully handles missing fields,
+    invalid data types, and non-positive orders. The `rank` parameter is currently
+    ignored, as only rank-1 decompositions are used for interaction terms.
+
+    Args:
+        config (dict): A dictionary containing the following optional keys:
+            - pure_indices (list[int]): List of positive integers indicating the
+                power orders for pure polynomial terms. Defaults to [].
+            - interact_indices (list[int]): List of positive integers indicating
+                the interaction orders. Each order m will produce a product of
+                m linear inner products. Defaults to [].
+            - interaction_form (str): Type of interaction. Only 'cp_inner_product'
+                is fully supported; other values trigger a warning but still
+                generate an expression using inner products. Defaults to
+                'cp_inner_product'.
+            - rank (int): CP rank; currently ignored.
+            - periodic (bool): If True, includes a periodic term <w_i, sin(x)>.
+                Defaults to False.
+
+    Returns:
+        str: A string representing the aggregation function, with terms joined by '+'.
+            Returns an empty string if no valid terms are present.
+
+    Raises:
+        TypeError: If `pure_indices` or `interact_indices` is present but not a list.
+
+    Examples:
+        >>> config = {'pure_indices': [1, 2], 'interact_indices': [2, 3]}
+        >>> neuronseek_config_to_string(config)
+        '<w1,x>+<w2,x**2>+<w3,x>*<w4,x>+<w5,x>*<w6,x>*<w7,x>'
+
+        >>> config = {'pure_indices': [1], 'interact_indices': [2], 'periodic': True}
+        >>> neuronseek_config_to_string(config)
+        '<w1,x>+<w2,x>*<w3,x>+<w4,sin(x)>'
+
+        >>> neuronseek_config_to_string({})
+        ''
+
+        >>> neuronseek_config_to_string({'pure_indices': [0, -1, 2]})
+        '<w1,x**2>'
+
+        >>> neuronseek_config_to_string({'pure_indices': 'not a list'})
+        Traceback (most recent call last):
+        ...
+        TypeError: 'pure_indices' must be a list
+    """
+
+    # ---- Safely retrieve and validate fields ----
+    pure = config.get('pure_indices')
+    if pure is None:
+        pure = []
+    if not isinstance(pure, list):
+        raise TypeError("'pure_indices' must be a list")
+
+    inter = config.get('interact_indices')
+    if inter is None:
+        inter = []
+    if not isinstance(inter, list):
+        raise TypeError("'interact_indices' must be a list")
+
+    # ---- Filter valid orders (positive integers) ----
+    def is_valid_order(v: any) -> bool:
+        """Return True if v is a positive integer."""
+        try:
+            return isinstance(v, int) and v > 0
+        except Exception:
+            return False
+
+    pure = [k for k in pure if is_valid_order(k)]
+    inter = [m for m in inter if is_valid_order(m)]
+
+    # ---- Warn about unsupported interaction_form ----
+    form = config.get('interaction_form', 'cp_inner_product')
+    if form != 'cp_inner_product':
+        import warnings
+        warnings.warn(
+            f"interaction_form '{form}' is not fully supported; "
+            "using cp_inner_product representation (rank 1).",
+            UserWarning
+        )
+
+    # ---- Build expression parts ----
+    parts = []
+    w_idx = 1   # weight vector counter
+
+    # Polynomial stream: each order k gives <w_i, x> (if k=1) or <w_i, x**k>
+    for k in pure:
+        if k == 1:
+            parts.append(f"<w{w_idx}, x>")
+        else:
+            parts.append(f"<w{w_idx}, x**{k}>")
+        w_idx += 1
+
+    # Interaction stream: each order m gives product of m linear inner products
+    for m in inter:
+        factors = []
+        for _ in range(m):
+            factors.append(f"<w{w_idx}, x>")
+            w_idx += 1
+        parts.append("*".join(factors))
+
+    # Periodic stream: if enabled, add <w_i, sin(x)>
+    if config.get('periodic', False):
+        parts.append(f"<w{w_idx}, sin(x)>")
+        w_idx += 1
+
+    return "+".join(parts)
+
+
+IP = InnerProduct

--- a/tnlearn/rl_regressor.py
+++ b/tnlearn/rl_regressor.py
@@ -1,27 +1,28 @@
-# Copyright 2026 Tieyun LI. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# ==============================================================================
 """
-Reinforcement Learning‑based Symbolic Regressor (Vectorized / Homogeneous version).
+Reinforcement Learning-based Symbolic Regressors.
 
-This module implements a policy gradient (REINFORCE) agent that selects a subset of
-basis functions (polynomials and optionally trigonometric/other terms) to form a
-symbolic expression. The expression is applied in a vectorized (homogeneous) manner:
-    F(x) = sum_k c_k * sum_j phi_k(x_j)
-Coefficients are fitted via Ridge regression on the training set, and the validation
-R² is used as the reward. The discovered expression can be used as a neuron formula
-in MLPRegressor.
+This module provides two RL-based symbolic regression implementations:
+1. RLSymRegressor (default, base): Discovers InnerProduct-based expressions:
+       f(x) = sum_i term_i(x)
+   where term_i are either phi_k = InnerProduct(w, x**k) or
+   psi_r = InnerProduct(w1,x)*...*InnerProduct(wr,x).
+2. RLRegressor (legacy): Discovers vectorized (homogeneous) expressions:
+       f(x) = sum_k c_k * sum_j phi_k(x_j)
+   with basis functions (polynomial, trigonometric, etc.).
+
+Copyright (c) 2026 Tieyun LI. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 """
 
 import torch
@@ -31,17 +32,67 @@ import numpy as np
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import r2_score
 from sklearn.linear_model import Ridge
-from typing import List, Optional, Tuple, Union
-import warnings
+from sklearn.preprocessing import StandardScaler
+from typing import List, Optional, Tuple
+from sympy import sympify, simplify, expand
+from .operator.inner_product import InnerProduct
+import re
 
-warnings.filterwarnings("ignore")
+
+# =============================================================================
+# Utility functions (shared)
+# =============================================================================
+
+def simplify_expr(expr_str: str) -> str:
+    """
+    Simplify a symbolic expression string that contains InnerProduct.
+
+    Parameters
+    ----------
+    expr_str : str
+        Expression string with InnerProduct calls.
+
+    Returns
+    -------
+    str
+        Simplified expression string.
+    """
+    try:
+        sym_expr = sympify(expr_str, locals={'InnerProduct': InnerProduct})
+        sym_expr = expand(sym_expr)
+        sym_expr = simplify(sym_expr)
+        return str(sym_expr)
+    except Exception:
+        return expr_str
+
+
+def format_pretty(expr_str: str) -> str:
+    """
+    Replace InnerProduct(...) with <...> for pretty printing.
+
+    Parameters
+    ----------
+    expr_str : str
+        Expression string with InnerProduct calls.
+
+    Returns
+    -------
+    str
+        Expression with InnerProduct replaced by angle brackets.
+    """
+    pattern = r'InnerProduct\(([^()]*)\)'
+    result = expr_str
+    while True:
+        new_result = re.sub(pattern, r'<\1>', result)
+        if new_result == result:
+            break
+        result = new_result
+    return result
+
 
 
 class PolicyNetwork(nn.Module):
-    """
-    Policy network that outputs a probability distribution over the basis functions.
-    """
-
+    """Policy network that outputs a probability distribution over the basis functions."""
     def __init__(self, n_funcs: int, hidden_dim: int = 64):
         super().__init__()
         self.net = nn.Sequential(
@@ -57,29 +108,38 @@ class PolicyNetwork(nn.Module):
         return self.net(state)
 
 
-class RLRegressor:
-    """
-    Reinforcement Learning symbolic regressor that discovers a vectorized (homogeneous)
-    expression of the form:
-        f(x) = sum_k c_k * sum_j phi_k(x_j)
 
-    The agent selects basis functions (phi_k), and Ridge regression fits the global
-    coefficients c_k. The search is done on the training set, and the reward is the
-    validation R². The discovered expression is compatible with VecSymRegressor format.
+# =============================================================================
+# RLSymRegressor (Base mode, default)
+# =============================================================================
+
+class RLSymRegressor:
+    """
+    Reinforcement Learning symbolic regressor that discovers expressions composed of
+    inner-product terms (base mode).
+
+    For base mode (default):
+        f(x) = sum_i term_i(x)
+    where each term_i is either:
+        - phi_k   = InnerProduct(w, x**k)          (k >= 1)
+        - psi_r   = InnerProduct(w1, x) * InnerProduct(w2, x) * ... * InnerProduct(wr, x)   (r >= 2)
+
+    Each term type can be selected multiple times; each instance gets distinct weights.
+
+    For legacy mode:
+        Delegates to RLRegressor, which discovers vectorized (homogeneous) expressions.
 
     Parameters
     ----------
-    basis_mode : str, default='trigonometric'
-        Determines the set of basis functions available:
-        - 'polynomial' : only polynomial terms: constant, x, x**2, ..., x**max_power
-        - 'trigonometric' : polynomial + sin(x), cos(x)
-        - 'all' : polynomial + sin(x), cos(x), exp(x), log(|x|)
-    max_terms : int, default=3
-        Maximum number of basis functions selected per expression.
+    mode : str, default='base'
+        'base'  : use InnerProduct-based expression discovery (this class).
+        'legacy': use the older RLRegressor (vectorized, homogeneous) implementation.
     max_power : int, default=5
-        Maximum exponent for polynomial terms (x**2 .. x**max_power). x and constant are always included.
+        Maximum exponent for polynomial terms (k up to max_power).
+    max_terms_psi : int, default=3
+        Maximum number of InnerProduct factors in a psi_r term (r up to this value).
     alpha : float, default=0.1
-        Regularisation strength for Ridge regression.
+        Regularisation strength for Ridge regression (used for evaluation only).
     random_state : int, default=42
         Random seed for reproducibility.
     max_episodes : int, default=100
@@ -92,10 +152,381 @@ class RLRegressor:
         Discount factor for reward calculation.
     hidden_dim : int, default=64
         Number of neurons in the policy network's hidden layers.
+    max_terms_total : int, default=4
+        Maximum number of selected terms in the expression (i.e., total number of phi_k and psi_r).
+    standardize : bool, default=True
+        If True, standardize the features (mean=0, std=1) internally to avoid numerical overflow.
+    output_mode : str, default='symbolic'
+        Output mode: 'symbolic' (keep w1, w2 as symbols) or 'numeric' (replace with actual coefficients).
     verbose : bool, default=True
         If True, print progress updates during training.
+
+    Additional legacy-only parameters (only used when mode='legacy'):
+    basis_mode : str, default='trigonometric'
+        Basis function set for the legacy regressor: 'polynomial', 'trigonometric', or 'all'.
     """
 
+    def __init__(
+        self,
+        mode: str = 'base',
+        max_power: int = 5,
+        max_terms_psi: int = 3,
+        alpha: float = 0.1,
+        random_state: int = 42,
+        max_episodes: int = 100,
+        val_split: float = 0.2,
+        lr_rl: float = 1e-3,
+        gamma: float = 0.99,
+        hidden_dim: int = 64,
+        max_terms_total: int = 4,
+        standardize: bool = True,
+        output_mode: str = 'symbolic',
+        verbose: bool = True,
+        # legacy-specific
+        basis_mode: str = 'trigonometric',
+    ):
+        self.mode = mode.lower()
+        if self.mode not in ('base', 'legacy'):
+            raise ValueError("mode must be 'base' or 'legacy'")
+
+        self.max_power = max_power
+        self.max_terms_psi = max_terms_psi
+        self.alpha = alpha
+        self.random_state = random_state
+        self.max_episodes = max_episodes
+        self.val_split = val_split
+        self.lr_rl = lr_rl
+        self.gamma = gamma
+        self.hidden_dim = hidden_dim
+        self.max_terms_total = max_terms_total
+        self.standardize = standardize
+        self.output_mode = output_mode.lower()
+        if self.output_mode not in ('symbolic', 'numeric'):
+            raise ValueError("output_mode must be 'symbolic' or 'numeric'")
+        self.verbose = verbose
+        self.basis_mode = basis_mode.lower()
+
+        np.random.seed(random_state)
+        torch.manual_seed(random_state)
+
+        # For base mode, initialize internals; for legacy, we will instantiate RLRegressor in fit.
+        if self.mode == 'base':
+            self.scaler_ = None
+            self.candidate_terms = []
+
+            # 1. phi_k = InnerProduct(w, x**k), k = 1..max_power
+            for k in range(1, self.max_power + 1):
+                self.candidate_terms.append({
+                    'type': 'phi',
+                    'k': k,
+                    'func_str': f'torch.sum(x**{k}, axis=1)',
+                    'display': f'phi_{k}'
+                })
+
+            # 2. psi_r = InnerProduct(w1, x) * InnerProduct(w2, x) * ... (r times)
+            for r in range(2, self.max_terms_psi + 1):
+                self.candidate_terms.append({
+                    'type': 'psi',
+                    'r': r,
+                    'func_str': f'(x.sum(axis=1))**{r}',
+                    'display': f'psi_{r}'
+                })
+
+            self.n_terms = len(self.candidate_terms)
+
+            self.policy = PolicyNetwork(self.n_terms, hidden_dim)
+            self.optimizer = optim.Adam(self.policy.parameters(), lr=lr_rl)
+
+            self.saved_log_probs = []
+            self.rewards = []
+            self.best_expr = None
+            self.best_score = -float('inf')
+            self.best_coeffs = None
+            self.best_intercept = None
+            self.best_selected_info = None
+            self.neuron = None
+
+        else:  # legacy
+            # We store parameters for lazy instantiation in fit
+            self._legacy_params = {
+                'basis_mode': basis_mode,
+                'max_terms': max_terms_total,
+                'max_power': max_power,
+                'alpha': alpha,
+                'random_state': random_state,
+                'max_episodes': max_episodes,
+                'val_split': val_split,
+                'lr_rl': lr_rl,
+                'gamma': gamma,
+                'hidden_dim': hidden_dim,
+                'verbose': verbose,
+            }
+            self.best_expr = None
+            self.best_score = -float('inf')
+            self.neuron = None
+
+    # ---------- Base mode methods ----------
+    @staticmethod
+    def _eval_func(func_str: str, x_tensor: torch.Tensor) -> np.ndarray:
+        try:
+            result = eval(func_str, {'x': x_tensor, 'torch': torch})
+            if isinstance(result, torch.Tensor):
+                return result.detach().numpy().flatten()
+            else:
+                return np.full(len(x_tensor), float(result), dtype=np.float64)
+        except Exception:
+            return np.full(len(x_tensor), np.nan)
+
+    def _evaluate_selection(
+        self,
+        selected_indices: List[int],
+        X_train: np.ndarray,
+        y_train: np.ndarray,
+        X_val: np.ndarray,
+        y_val: np.ndarray,
+    ) -> Tuple[float, np.ndarray, float, List[dict]]:
+        if not selected_indices:
+            return -1e6, np.array([]), 0.0, []
+
+        n_train, d = X_train.shape
+        n_val = X_val.shape[0]
+        K = len(selected_indices)
+
+        X_train_t = torch.tensor(X_train, dtype=torch.float32)
+        X_val_t = torch.tensor(X_val, dtype=torch.float32)
+
+        A_train = np.zeros((n_train, K))
+        A_val = np.zeros((n_val, K))
+        selected_info = []
+
+        for k, idx in enumerate(selected_indices):
+            term = self.candidate_terms[idx]
+            func_str = term['func_str']
+            try:
+                phi_train = self._eval_func(func_str, X_train_t)
+                phi_val = self._eval_func(func_str, X_val_t)
+            except Exception:
+                return -1e6, np.array([]), 0.0, []
+
+            if np.any(np.isnan(phi_train)) or np.any(np.isnan(phi_val)):
+                return -1e6, np.array([]), 0.0, []
+
+            A_train[:, k] = phi_train
+            A_val[:, k] = phi_val
+            selected_info.append(term)
+
+        ridge = Ridge(alpha=self.alpha, fit_intercept=True)
+        ridge.fit(A_train, y_train)
+        coeffs = ridge.coef_
+        intercept = ridge.intercept_
+
+        y_pred_val = ridge.predict(A_val)
+        r2 = r2_score(y_val, y_pred_val)
+
+        return r2, coeffs, intercept, selected_info
+
+    def _build_expr_symbolic(self, selected_info: List[dict]) -> str:
+        terms = []
+        weight_counter = 1
+        for info in selected_info:
+            if info['type'] == 'phi':
+                w_sym = f"w{weight_counter}"
+                weight_counter += 1
+                term_str = f"InnerProduct({w_sym}, x**{info['k']})"
+            else:  # psi
+                r = info['r']
+                inner_prods = []
+                for _ in range(r):
+                    w_sym = f"w{weight_counter}"
+                    weight_counter += 1
+                    inner_prods.append(f"InnerProduct({w_sym}, x)")
+                term_str = " * ".join(inner_prods)
+            terms.append(term_str)
+        if not terms:
+            return "0"
+        expr = " + ".join(terms)
+        expr = expr.replace("+ -", "- ")
+        return expr
+
+    def _build_expr_numeric(self, selected_info: List[dict], coeffs: np.ndarray, intercept: float) -> str:
+        terms = []
+        if abs(intercept) > 1e-8:
+            terms.append(f"{intercept:.6f}")
+        for info, c in zip(selected_info, coeffs):
+            if abs(c) < 1e-8:
+                continue
+            if info['type'] == 'phi':
+                term_str = f"InnerProduct({c:.6f}, x**{info['k']})"
+            else:
+                r = info['r']
+                inner_prods = " * ".join(["InnerProduct(1, x)"] * r)
+                term_str = f"{c:.6f} * {inner_prods}"
+            terms.append(term_str)
+        if not terms:
+            return "0"
+        expr = " + ".join(terms)
+        expr = expr.replace("+ -", "- ")
+        return expr
+
+    def _select_action(self) -> Tuple[List[int], torch.Tensor]:
+        state = torch.tensor([0.0])
+        probs = self.policy(state).squeeze(0)
+        sampled = []
+        log_prob = 0.0
+        for _ in range(self.max_terms_total):
+            idx = torch.multinomial(probs, 1).item()
+            sampled.append(idx)
+            log_prob += torch.log(probs[idx] + 1e-10)
+        return sampled, log_prob
+
+    # ---------- Public fit method ----------
+    def fit(self, X: np.ndarray, y: np.ndarray) -> None:
+        """
+        Train the RL agent to discover the best symbolic expression.
+
+        Parameters
+        ----------
+        X : np.ndarray, shape (n_samples, n_features)
+            Input data (can be multi-dimensional).
+        y : np.ndarray, shape (n_samples,)
+            Target values.
+        """
+        if X.ndim == 1:
+            X = X.reshape(-1, 1)
+
+        # ---------- Legacy mode ----------
+        if self.mode == 'legacy':
+            # Instantiate RLRegressor with stored parameters
+            legacy = RLRegressor(**self._legacy_params)
+            legacy.fit(X, y)
+            self.best_expr = legacy.best_expr
+            self.best_score = legacy.best_score
+            self.neuron = legacy.neuron
+            return
+
+        # ---------- Base mode ----------
+        X_train, X_val, y_train, y_val = train_test_split(
+            X, y, test_size=self.val_split, random_state=self.random_state
+        )
+
+        if self.standardize:
+            self.scaler_ = StandardScaler()
+            X_train = self.scaler_.fit_transform(X_train)
+            X_val = self.scaler_.transform(X_val)
+            if self.verbose:
+                print("  → Standardized features (mean=0, std=1)")
+
+        for episode in range(self.max_episodes):
+            selected, log_prob = self._select_action()
+            self.saved_log_probs.append(log_prob)
+
+            reward, coeffs, intercept, selected_info = self._evaluate_selection(
+                selected, X_train, y_train, X_val, y_val
+            )
+            self.rewards.append(reward)
+
+            if reward > self.best_score:
+                self.best_score = reward
+                if selected_info:
+                    self.best_coeffs = coeffs
+                    self.best_intercept = intercept
+                    self.best_selected_info = selected_info
+
+                    if self.output_mode == 'symbolic':
+                        raw_expr = self._build_expr_symbolic(selected_info)
+                    else:
+                        raw_expr = self._build_expr_numeric(selected_info, coeffs, intercept)
+
+                    simplified = simplify_expr(raw_expr)
+                    self.best_expr = simplified
+                else:
+                    self.best_expr = "0"
+                if self.verbose:
+                    print(f"\rEpisode {episode+1}: found better expression '{self.best_expr}' (val R²={reward:.4f})", end="")
+
+            # REINFORCE update
+            R = 0
+            returns = []
+            for r in reversed(self.rewards):
+                R = r + self.gamma * R
+                returns.insert(0, R)
+            returns = torch.tensor(returns)
+            if len(returns) > 1 and returns.std() > 1e-8:
+                returns = (returns - returns.mean()) / (returns.std() + 1e-8)
+            elif len(returns) > 1:
+                returns = returns - returns.mean()
+
+            policy_loss = []
+            for logp, ret in zip(self.saved_log_probs, returns):
+                policy_loss.append(-logp * ret)
+            self.optimizer.zero_grad()
+            torch.stack(policy_loss).sum().backward()
+            self.optimizer.step()
+
+            self.saved_log_probs = []
+            self.rewards = []
+
+            if self.verbose and (episode + 1) % 10 == 0 and reward <= self.best_score:
+                print(f"\rEpisode {episode+1}/{self.max_episodes}, current best R²={self.best_score:.4f}   ", end="")
+
+        if self.verbose:
+            print()
+            print(f"RL search completed. Best expression: {self.best_expr}, validation R² = {self.best_score:.4f}")
+
+        # Store pretty version in neuron attribute
+        if self.best_expr:
+            self.neuron = format_pretty(self.best_expr)
+        else:
+            self.neuron = "0"
+
+    def get_neuron(self) -> Optional[str]:
+        """Return the best discovered neuron formula in pretty format."""
+        return self.neuron
+
+    def get_raw_expr(self) -> Optional[str]:
+        """Return the raw (non-pretty) simplified expression."""
+        return self.best_expr
+
+
+# =============================================================================
+# RLRegressor (Legacy mode)
+# =============================================================================
+
+class RLRegressor:
+    """
+    Reinforcement Learning symbolic regressor (legacy, vectorized/homogeneous).
+
+    Discovers expressions of the form:
+        f(x) = sum_k c_k * sum_j phi_k(x_j)
+
+    The agent selects basis functions (phi_k), and Ridge regression fits the global
+    coefficients c_k. The reward is validation R².
+
+    Parameters
+    ----------
+    basis_mode : str, default='trigonometric'
+        Basis function set: 'polynomial', 'trigonometric', or 'all'.
+    max_terms : int, default=3
+        Maximum number of basis functions selected per expression.
+    max_power : int, default=5
+        Maximum exponent for polynomial terms.
+    alpha : float, default=0.1
+        Regularisation strength for Ridge regression.
+    random_state : int, default=42
+        Random seed.
+    max_episodes : int, default=100
+        Number of training episodes.
+    val_split : float, default=0.2
+        Fraction of training data used as validation.
+    lr_rl : float, default=1e-3
+        Learning rate for policy network.
+    gamma : float, default=0.99
+        Discount factor.
+    hidden_dim : int, default=64
+        Number of neurons in policy network hidden layers.
+    verbose : bool, default=True
+        Print progress.
+    """
     def __init__(
         self,
         basis_mode: str = 'trigonometric',
@@ -112,8 +543,7 @@ class RLRegressor:
     ):
         self.basis_mode = basis_mode.lower()
         if self.basis_mode not in ['polynomial', 'trigonometric', 'all']:
-            raise ValueError("basis_mode must be one of 'polynomial', 'trigonometric', or 'all'")
-
+            raise ValueError("basis_mode must be 'polynomial', 'trigonometric', or 'all'")
         self.max_terms = max_terms
         self.max_power = max_power
         self.alpha = alpha
@@ -127,26 +557,21 @@ class RLRegressor:
         np.random.seed(random_state)
         torch.manual_seed(random_state)
 
-        # Build candidate basis functions based on mode and max_power
+        # Build candidate basis functions
         self.candidate_funcs = []
-        # Constant term (torch.ones_like(x))
-        self.candidate_funcs.append('torch.ones_like(x)')
-        # Linear term
-        self.candidate_funcs.append('x')
-        # Higher powers
+        self.candidate_funcs.append('torch.ones_like(x)')  # constant
+        self.candidate_funcs.append('x')                   # linear
         for p in range(2, self.max_power + 1):
             self.candidate_funcs.append(f'x**{p}')
 
         if self.basis_mode in ['trigonometric', 'all']:
             self.candidate_funcs.append('torch.sin(x)')
             self.candidate_funcs.append('torch.cos(x)')
-
         if self.basis_mode == 'all':
             self.candidate_funcs.append('torch.exp(x)')
             self.candidate_funcs.append('torch.log(torch.abs(x) + 1e-8)')
 
         self.n_funcs = len(self.candidate_funcs)
-
         self.policy = PolicyNetwork(self.n_funcs, hidden_dim)
         self.optimizer = optim.Adam(self.policy.parameters(), lr=lr_rl)
 
@@ -158,10 +583,6 @@ class RLRegressor:
 
     @staticmethod
     def _eval_func(func_str: str, x_tensor: torch.Tensor) -> np.ndarray:
-        """
-        Safely evaluate a basis function on a 1D torch tensor.
-        Returns a numpy array of shape (n_samples,).
-        """
         try:
             result = eval(func_str, globals(), {'x': x_tensor, 'torch': torch})
             if isinstance(result, torch.Tensor):
@@ -179,20 +600,6 @@ class RLRegressor:
         X_val: np.ndarray,
         y_val: np.ndarray,
     ) -> Tuple[float, Optional[np.ndarray], float, List[str]]:
-        """
-        Evaluate a set of selected basis functions in a vectorized (homogeneous) way.
-
-        For each selected basis function phi_k, we compute:
-            phi_k(X)  ->  sum over features (axis=1)
-        Then we stack these columns and fit a Ridge regression to obtain global coefficients.
-        The reward is the validation R².
-
-        Returns:
-            r2 : validation R²
-            coeffs : fitted coefficients (length K)
-            intercept : fitted intercept
-            funcs : list of selected basis function strings (order matches coeffs)
-        """
         if not selected_indices:
             return -1e6, None, 0.0, []
 
@@ -238,13 +645,7 @@ class RLRegressor:
         return r2, coeffs, intercept, selected_funcs
 
     def _build_expr(self, funcs: List[str], coeffs: np.ndarray, intercept: float) -> str:
-        """
-        Build a human‑readable expression string in the format:
-            intercept + c1@phi1 + c2@phi2 + ...
-        where phi_k are the basis function strings.
-        """
         terms = []
-        # Add constant term if intercept is non‑zero
         if abs(intercept) > 1e-8:
             if abs(intercept - round(intercept)) < 1e-8:
                 terms.append(str(int(round(intercept))))
@@ -255,14 +656,9 @@ class RLRegressor:
             if abs(c) < 1e-8:
                 continue
             c_str = str(int(round(c))) if abs(c - round(c)) < 1e-8 else f"{c:.4f}"
-            # For constant function, we treat it as a separate term, but we already handled intercept.
             if func == "torch.ones_like(x)":
-                # Skip constant term because intercept already accounts for it.
-                # However, if intercept is zero and constant term has non‑zero coefficient,
-                # we should add it. We'll just add it as a separate term.
                 terms.append(c_str)
             else:
-                # Wrap composite expressions in parentheses
                 if any(op in func for op in ['+', '-', '*', '/', '**', 'sin', 'cos', 'exp', 'log']):
                     func = f"({func})"
                 terms.append(f"{c_str}@{func}")
@@ -274,29 +670,18 @@ class RLRegressor:
         return expr
 
     def _select_action(self) -> Tuple[List[int], torch.Tensor]:
-        """Sample up to max_terms basis functions (with replacement) and remove duplicates."""
         state = torch.tensor([0.0])
-        probs = self.policy(state).squeeze(0)  # (n_funcs,)
+        probs = self.policy(state).squeeze(0)
         sampled = []
         log_prob = 0.0
         for _ in range(self.max_terms):
             idx = torch.multinomial(probs, 1).item()
             sampled.append(idx)
             log_prob += torch.log(probs[idx] + 1e-10)
-        selected = list(dict.fromkeys(sampled))  # remove duplicates, preserve order
+        selected = list(dict.fromkeys(sampled))  # remove duplicates
         return selected, log_prob
 
     def fit(self, X: np.ndarray, y: np.ndarray) -> None:
-        """
-        Train the RL agent to discover the best vectorized symbolic expression.
-
-        Parameters
-        ----------
-        X : np.ndarray, shape (n_samples, n_features)
-            Input data (can be multi‑dimensional).
-        y : np.ndarray, shape (n_samples,)
-            Target values.
-        """
         if X.ndim == 1:
             X = X.reshape(-1, 1)
 
@@ -354,5 +739,5 @@ class RLRegressor:
         self.neuron = self.best_expr
 
     def get_neuron(self) -> Optional[str]:
-        """Return the best discovered neuron formula."""
         return self.neuron
+


### PR DESCRIPTION
- Add inner_product.py with InnerProduct class, parameterization, and evaluation utilities
- Support InnerProduct in all core modules: GP, RL, LLM, MLP, CNN, RNN, Transformer
- Introduce 'base' and 'legacy' modes across all estimators and layers
- Rename VecSymRegressor → GPSymRegressor (new default); VecSymRegressor retained as legacy
- Implement scikit-learn get_params/set_params for MLP estimators
- Add automatic conversion of non-IP expressions in DRSR (base mode)
- Add parent_selection strategy to GPSymRegressor
- Update DRSR modules for mode switching
- Add convert_innerproduct_to_pretty for pretty-printing
- Update examples, benchmarks, and tests accordingly