### PR TITLE
feat: add already_parametrized flag to BaseCustomNeuronLayer and modules

### DIFF
--- a/tests/test_mlpclassifier.py
+++ b/tests/test_mlpclassifier.py
@@ -32,21 +32,41 @@ X = preprocessor.fit_transform(X)
 # Splitting the dataset into training and test sets with an 80-20 ratio.
 X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
 
-# Constructing the neural network classifier with specific parameters.
-mlp = MLPClassifier(neurons='x**2',
+# Constructing the neural network classifier with specific parameters. (legacy mode)
+mlp1 = MLPClassifier(neurons='x**2',
                     layers_list=[10, 10, 10],
                     activation_funcs='sigmoid',
                     optimizer_name='adam',
                     max_iter=200,
                     batch_size=16,
-                    mode='lagacy'
+                    mode='legacy'
                     )
 
 # Training the MLPClassifier using the training data.
-mlp.fit(X_train, y_train)
+mlp1.fit(X_train, y_train)
 
 # Generating predictions for the test set.
-y_pred = mlp.predict(X_test)
+y_pred1 = mlp1.predict(X_test)
 
 # Scoring the model based on accuracy using the predictions and actual labels.
-accuracy = mlp.score(X_test, y_test)
+accuracy1 = mlp1.score(X_test, y_test)
+
+# Constructing a second MLPClassifier with a different neuron configuration (base mode).
+mlp2 = MLPClassifier(neurons='<w1,x**2>',
+                    layers_list=[10, 10, 10],
+                    activation_funcs='sigmoid',
+                    optimizer_name='adam',
+                    max_iter=200,
+                    batch_size=16,
+                    mode='base',
+                    already_parametrized=True
+                    )
+
+# Training the second MLPClassifier using the same training data.
+mlp2.fit(X_train, y_train)
+
+# Generating predictions for the test set using the second model.
+y_pred2 = mlp2.predict(X_test)
+
+# Scoring the second model based on accuracy using its predictions and actual labels.
+accuracy2 = mlp2.score(X_test, y_test)

--- a/tests/test_mlpregressor.py
+++ b/tests/test_mlpregressor.py
@@ -35,22 +35,47 @@ X_train = preprocessor.fit_transform(X_train)
 # Transform test data only
 X_test = preprocessor.transform(X_test)
 
-# Instantiate the MLPRegressor class with specified parameters
-mlp_regressor = MLPRegressor(neurons='x**2',
+# Instantiate the MLPRegressor class with specified parameters. (legacy mode)
+mlp1 = MLPRegressor(neurons='x**2',
                              layers_list=[50, 30, 10],
                              activation_funcs='sigmoid',
                              loss_function='mse',
                              optimizer_name='adam',
                              max_iter=200,
                              batch_size=16,
-                             mode='lagacy'
+                             mode='legacy'
                              )
 
 # Train the MLP regressor model on the preprocessed training data
-mlp_regressor.fit(X_train, y_train)
+mlp1.fit(X_train, y_train)
 
 # Evaluate the model's performance on the test set
-test_score = mlp_regressor.score(X_test, y_test)
+test_score1 = mlp1.score(X_test, y_test)
 
 # Perform predictions using the trained MLP regressor on the test data
-predictions = mlp_regressor.predict(X_test)
+predictions1 = mlp1.predict(X_test)
+
+# Instantiate a second MLPRegressor with a different neuron configuration (base mode)
+mlp2 = MLPRegressor(neurons='<w1, x**2>',
+                             layers_list=[50, 30, 10],
+                             activation_funcs='sigmoid',
+                             loss_function='mse',
+                             optimizer_name='adam',
+                             max_iter=200,
+                             batch_size=16,
+                             mode='base',
+                             already_parametrized=True
+                             )
+
+# Train the second MLP regressor model on the same preprocessed training data
+mlp2.fit(X_train, y_train)
+
+# Evaluate the second model's performance on the test set
+test_score2 = mlp2.score(X_test, y_test)
+
+
+# Perform predictions using the second trained MLP regressor on the test data
+predictions2 = mlp2.predict(X_test)
+
+print(f"Test score of MLPRegressor (legacy mode): {test_score1:.4f}")
+print(f"Test score of MLPRegressor (base mode): {test_score2:.4f}")

--- a/tests/test_mlpregressor.py
+++ b/tests/test_mlpregressor.py
@@ -76,6 +76,3 @@ test_score2 = mlp2.score(X_test, y_test)
 
 # Perform predictions using the second trained MLP regressor on the test data
 predictions2 = mlp2.predict(X_test)
-
-print(f"Test score of MLPRegressor (legacy mode): {test_score1:.4f}")
-print(f"Test score of MLPRegressor (base mode): {test_score2:.4f}")

--- a/tests/test_tntransformer.py
+++ b/tests/test_tntransformer.py
@@ -22,7 +22,8 @@ from tnlearn import (
 def compare_tensors(out1, out2, atol=1e-6):
     """Recursively compare two outputs, supporting nested tuples/lists."""
     if isinstance(out1, torch.Tensor):
-        assert torch.allclose(out1, out2, atol=atol), f"Tensor mismatch: {out1} vs {out2}"
+        # Allow NaN equality, as masked softmax may produce NaN in edge cases
+        assert torch.allclose(out1, out2, atol=atol, equal_nan=True), f"Tensor mismatch: {out1} vs {out2}"
     elif isinstance(out1, (tuple, list)):
         assert len(out1) == len(out2), f"Length mismatch: {len(out1)} vs {len(out2)}"
         for a, b in zip(out1, out2):
@@ -101,7 +102,7 @@ def test_transformer_models():
     """Test all Transformer components with TNLinear."""
     torch.manual_seed(42)
 
-    # ---------- 1. TNTransformerEncoderLayer ----------
+    # ---------- 1. TNTransformerEncoderLayer (batch_first=False) ----------
     print("Testing TNTransformerEncoderLayer (batch_first=False)...")
     encoder_layer = TNTransformerEncoderLayer(
         d_model=512, nhead=8, dim_feedforward=2048,
@@ -138,10 +139,11 @@ def test_transformer_models():
     enc_layer = TNTransformerEncoderLayer(
         d_model=512, nhead=8, dim_feedforward=2048,
         dropout=0.1, activation='relu',
-        symbolic_expression='x + 0.5 * sin(x)'
+        symbolic_expression='x + 0.5 * sin(x)',
+        batch_first=True,   # Use batch_first to enable nested tensor optimization
     )
     encoder = TNTransformerEncoder(enc_layer, num_layers=2)
-    src = torch.randn(10, 32, 512)
+    src = torch.randn(32, 10, 512)   # (batch, seq, feature)
     test_model_save_load(encoder, (src,))
 
     # ---------- 4. TNTransformerDecoder (stack) ----------
@@ -156,7 +158,7 @@ def test_transformer_models():
     memory = torch.randn(10, 32, 512)
     test_model_save_load(decoder, (tgt, memory))
 
-    # ---------- 5. Full TNTransformer ----------
+    # ---------- 5. Full TNTransformer (batch_first=True to avoid nested tensor warning) ----------
     print("Testing TNTransformer (full model)...")
     transformer = TNTransformer(
         d_model=512, nhead=8,
@@ -164,10 +166,10 @@ def test_transformer_models():
         dim_feedforward=2048, dropout=0.1,
         activation='relu',
         symbolic_expression='x + tanh(x)',
-        batch_first=False
+        batch_first=True   # Use batch_first=True to avoid warning and enable optimization
     )
-    src = torch.randn(10, 32, 512)
-    tgt = torch.randn(20, 32, 512)
+    src = torch.randn(32, 10, 512)   # (batch, seq, feature)
+    tgt = torch.randn(32, 20, 512)   # (batch, seq, feature)
     test_model_save_load(transformer, (src, tgt))
 
     # ---------- 6. Test with masks and batch_first=True ----------
@@ -183,7 +185,8 @@ def test_transformer_models():
     src_bf = torch.randn(32, 10, 512)
     tgt_bf = torch.randn(32, 20, 512)
 
-    tgt_mask = transformer_bf.generate_square_subsequent_mask(20)
+    # Convert mask to bool to avoid deprecation warning
+    tgt_mask = transformer_bf.generate_square_subsequent_mask(20).bool()
     src_key_padding_mask = torch.randint(0, 2, (32, 10)).bool()
     tgt_key_padding_mask = torch.randint(0, 2, (32, 20)).bool()
 

--- a/tnlearn/mlpclassifier.py
+++ b/tnlearn/mlpclassifier.py
@@ -67,10 +67,10 @@ class BaseCustomNeuronLayer(nn.Module):
             to inner product terms, regardless of whether new weight symbols are generated.
             If False, the original logic applies: an extra coefficient 'c' is added only when
             no new weight symbol is generated during parameterization.
-            Default: True.
+            Default: False.
     """
     def __init__(self, in_features: int, out_features: int, symbolic_expression: str,
-                 bias: bool = True, already_parametrized: bool = True):
+                 bias: bool = True, already_parametrized: bool = False):
         super().__init__()
         self.in_features = in_features
         self.out_features = out_features

--- a/tnlearn/mlpclassifier.py
+++ b/tnlearn/mlpclassifier.py
@@ -56,12 +56,26 @@ from tnlearn.operator.inner_product import (
 class BaseCustomNeuronLayer(nn.Module):
     """
     Custom neuron layer using SymPy parameterization with InnerProduct.
+
+    Args:
+        in_features: input dimension
+        out_features: output dimension
+        symbolic_expression: string representation of the neuron's mathematical form
+        bias: whether to add a learnable bias (kept for compatibility, but biases are already handled via b_i)
+        already_parametrized: if True, the expression is assumed to already contain parameter symbols
+            (e.g., w1, c1, b1). In this case, no extra coefficient 'c' will be automatically added
+            to inner product terms, regardless of whether new weight symbols are generated.
+            If False, the original logic applies: an extra coefficient 'c' is added only when
+            no new weight symbol is generated during parameterization.
+            Default: True.
     """
-    def __init__(self, in_features: int, out_features: int, symbolic_expression: str, bias: bool = True):
+    def __init__(self, in_features: int, out_features: int, symbolic_expression: str,
+                 bias: bool = True, already_parametrized: bool = True):
         super().__init__()
         self.in_features = in_features
         self.out_features = out_features
         self.raw_expr = symbolic_expression
+        self.already_parametrized = already_parametrized
 
         # 1. Convert to InnerProduct format
         expr_str = convert_pretty_to_innerproduct(symbolic_expression)
@@ -75,8 +89,9 @@ class BaseCustomNeuronLayer(nn.Module):
         sym_expr = expand(sym_expr)
         sym_expr = simplify(sym_expr)
 
-        # 2. Parameterize (including bias symbols b_i)
-        self.param_expr = parameterize_expression(sym_expr, include_bias=True)
+        # 2. Parameterize, passing the already_parametrized flag
+        self.param_expr = parameterize_expression(sym_expr, include_bias=True,
+                                                  already_parametrized=already_parametrized)
         self.param_expr_str = str(self.param_expr)
 
         # 3. Extract all symbols
@@ -168,6 +183,7 @@ class MLPClassifier(BaseModel):
                  l1_reg=False,
                  l2_reg=False,
                  mode='base',
+                 already_parametrized=True,
                  ):
         r"""Construct MLPClassifier with task-based neurons.
 
@@ -193,6 +209,14 @@ class MLPClassifier(BaseModel):
             mode (str): Which neuron layer implementation to use:
                        'base'  -> BaseCustomNeuronLayer (SymPy + InnerProduct)
                        'legacy' -> LegacyCustomNeuronLayer (from tnlearn.neurons)
+            already_parametrized (bool): Only effective when mode='base'.
+                       If True, the expression is assumed to already contain parameter symbols
+                       (e.g., w1, c1, b1). In this case, no extra coefficient 'c' will be
+                       automatically added to inner product terms, regardless of whether new
+                       weight symbols are generated during parameterization.
+                       If False, the original logic applies: an extra coefficient 'c' is added
+                       only when no new weight symbol is generated.
+                       Default: True.
         """
         super(MLPClassifier, self).__init__()
 
@@ -210,6 +234,7 @@ class MLPClassifier(BaseModel):
         self.l1_reg = l1_reg
         self.l2_reg = l2_reg
         self.mode = mode
+        self.already_parametrized = already_parametrized
         if self.mode.lower() not in ('base', 'legacy'):
             raise ValueError("mode must be 'base' or 'legacy'")
 
@@ -276,6 +301,7 @@ class MLPClassifier(BaseModel):
             'l1_reg': self.l1_reg,
             'l2_reg': self.l2_reg,
             'mode': self.mode,
+            'already_parametrized': self.already_parametrized,
         }
 
     def set_params(self, **params):
@@ -329,18 +355,28 @@ class MLPClassifier(BaseModel):
         # Choose the appropriate CustomNeuronLayer class based on mode
         if self.mode.lower() == 'legacy':
             layer_class = LegacyCustomNeuronLayer
+            # Legacy mode does not support already_parametrized; ignore
         else:
             layer_class = BaseCustomNeuronLayer
 
         layers = []
         last_dim = input_dim
         for neuron_count in self.layers_list:
-            layers.append(layer_class(last_dim, neuron_count, self.neurons))
+            # Only pass already_parametrized when using base mode
+            if self.mode.lower() == 'base':
+                layers.append(layer_class(last_dim, neuron_count, self.neurons,
+                                          already_parametrized=self.already_parametrized))
+            else:
+                layers.append(layer_class(last_dim, neuron_count, self.neurons))
             last_dim = neuron_count
             layers.append(self.activation_funcs)
 
         # Output layer: also uses the same CustomNeuronLayer (no activation, handled by CrossEntropyLoss)
-        layers.append(layer_class(last_dim, output_dim, self.neurons))
+        if self.mode.lower() == 'base':
+            layers.append(layer_class(last_dim, output_dim, self.neurons,
+                                      already_parametrized=self.already_parametrized))
+        else:
+            layers.append(layer_class(last_dim, output_dim, self.neurons))
         return nn.Sequential(*layers)
 
     def prepare_data(self, X, y):

--- a/tnlearn/mlpregressor.py
+++ b/tnlearn/mlpregressor.py
@@ -67,10 +67,10 @@ class BaseCustomNeuronLayer(nn.Module):
             to inner product terms, regardless of whether new weight symbols are generated.
             If False, the original logic applies: an extra coefficient 'c' is added only when
             no new weight symbol is generated during parameterization.
-            Default: True.
+            Default: False.
     """
     def __init__(self, in_features: int, out_features: int, symbolic_expression: str,
-                 bias: bool = True, already_parametrized: bool = True):
+                 bias: bool = True, already_parametrized: bool = False):
         super().__init__()
         self.in_features = in_features
         self.out_features = out_features

--- a/tnlearn/mlpregressor.py
+++ b/tnlearn/mlpregressor.py
@@ -56,12 +56,26 @@ from tnlearn.operator.inner_product import (
 class BaseCustomNeuronLayer(nn.Module):
     """
     Custom neuron layer using SymPy parameterization with InnerProduct.
+
+    Args:
+        in_features: input dimension
+        out_features: output dimension
+        symbolic_expression: string representation of the neuron's mathematical form
+        bias: whether to add a learnable bias (kept for compatibility, but biases are already handled via b_i)
+        already_parametrized: if True, the expression is assumed to already contain parameter symbols
+            (e.g., w1, c1, b1). In this case, no extra coefficient 'c' will be automatically added
+            to inner product terms, regardless of whether new weight symbols are generated.
+            If False, the original logic applies: an extra coefficient 'c' is added only when
+            no new weight symbol is generated during parameterization.
+            Default: True.
     """
-    def __init__(self, in_features: int, out_features: int, symbolic_expression: str, bias: bool = True):
+    def __init__(self, in_features: int, out_features: int, symbolic_expression: str,
+                 bias: bool = True, already_parametrized: bool = True):
         super().__init__()
         self.in_features = in_features
         self.out_features = out_features
         self.raw_expr = symbolic_expression
+        self.already_parametrized = already_parametrized
 
         # 1. Convert to InnerProduct format
         expr_str = convert_pretty_to_innerproduct(symbolic_expression)
@@ -75,8 +89,9 @@ class BaseCustomNeuronLayer(nn.Module):
         sym_expr = expand(sym_expr)
         sym_expr = simplify(sym_expr)
 
-        # 2. Parameterize
-        self.param_expr = parameterize_expression(sym_expr, include_bias=True)
+        # 2. Parameterize, passing the already_parametrized flag
+        self.param_expr = parameterize_expression(sym_expr, include_bias=True,
+                                                  already_parametrized=already_parametrized)
         self.param_expr_str = str(self.param_expr)
 
         # 3. Extract all symbols
@@ -168,6 +183,7 @@ class MLPRegressor(BaseModel1):
                  l1_reg=False,
                  l2_reg=False,
                  mode='base',
+                 already_parametrized=True,
                  ):
         r"""Construct MLPRegressor with task-based neurons.
 
@@ -193,6 +209,14 @@ class MLPRegressor(BaseModel1):
             mode (str): Which neuron layer implementation to use:
                        'base'  -> BaseCustomNeuronLayer (SymPy + InnerProduct)
                        'legacy' -> LegacyCustomNeuronLayer (from tnlearn.neurons)
+            already_parametrized (bool): Only effective when mode='base'.
+                       If True, the expression is assumed to already contain parameter symbols
+                       (e.g., w1, c1, b1). In this case, no extra coefficient 'c' will be
+                       automatically added to inner product terms, regardless of whether new
+                       weight symbols are generated during parameterization.
+                       If False, the original logic applies: an extra coefficient 'c' is added
+                       only when no new weight symbol is generated.
+                       Default: True.
         """
         super(MLPRegressor, self).__init__()
 
@@ -210,6 +234,7 @@ class MLPRegressor(BaseModel1):
         self.l1_reg = l1_reg
         self.l2_reg = l2_reg
         self.mode = mode
+        self.already_parametrized = already_parametrized
         if self.mode.lower() not in ('base', 'legacy'):
             raise ValueError("mode must be 'base' or 'legacy'")
 
@@ -272,6 +297,7 @@ class MLPRegressor(BaseModel1):
             'l1_reg': self.l1_reg,
             'l2_reg': self.l2_reg,
             'mode': self.mode,
+            'already_parametrized': self.already_parametrized,
         }
 
     def set_params(self, **params):
@@ -322,13 +348,19 @@ class MLPRegressor(BaseModel1):
         # Choose the appropriate CustomNeuronLayer class based on mode
         if self.mode.lower() == 'legacy':
             layer_class = LegacyCustomNeuronLayer
+            # Legacy mode does not support already_parametrized; ignore
         else:
             layer_class = BaseCustomNeuronLayer
 
         layers = []
         last_dim = input_dim
         for neuron_count in self.layers_list:
-            layers.append(layer_class(last_dim, neuron_count, self.neurons))
+            # Only pass already_parametrized when using base mode
+            if self.mode.lower() == 'base':
+                layers.append(layer_class(last_dim, neuron_count, self.neurons,
+                                          already_parametrized=self.already_parametrized))
+            else:
+                layers.append(layer_class(last_dim, neuron_count, self.neurons))
             last_dim = neuron_count
             layers.append(self.activation_funcs)
 

--- a/tnlearn/modules/TNconv.py
+++ b/tnlearn/modules/TNconv.py
@@ -49,17 +49,19 @@ def _process_inner_product(ip, counter):
     new_right = expand(simplify(right))
     return InnerProduct(new_left, new_right)
 
-def parameterize_term_conv(term, counter):
+def parameterize_term_conv(term, counter, already_parametrized=False):
     if term.is_number:
         return 0
     if is_inner_product(term):
         new_ip = _process_inner_product(term, counter)
-        if term.left.is_Number:
-            return new_ip
-        else:
+        # Determine if a new weight symbol was generated (i.e., left operand was a number)
+        created_param = term.left.is_Number
+        if not created_param and not already_parametrized:
             c = symbols('c%d' % counter['c'])
             counter['c'] += 1
             return Mul(c, new_ip)
+        else:
+            return new_ip
     if isinstance(term, Mul):
         inner_products = []
         non_inner = []
@@ -87,7 +89,7 @@ def parameterize_term_conv(term, counter):
         if not inner_products:
             return 1
         result = Mul(*inner_products) if len(inner_products) > 1 else inner_products[0]
-        if not created_param:
+        if not created_param and not already_parametrized:
             c = symbols('c%d' % counter['c'])
             counter['c'] += 1
             result = Mul(c, result)
@@ -97,7 +99,7 @@ def parameterize_term_conv(term, counter):
     counter['w'] += 1
     return InnerProduct(w, new_expr)
 
-def parameterize_expression_conv(expr):
+def parameterize_expression_conv(expr, already_parametrized=False):
     if isinstance(expr, Add):
         terms = list(expr.args)
     else:
@@ -105,7 +107,7 @@ def parameterize_expression_conv(expr):
     counter = {'w': 1, 'b': 1, 'c': 1}
     new_terms = []
     for t in terms:
-        pt = parameterize_term_conv(t, counter)
+        pt = parameterize_term_conv(t, counter, already_parametrized)
         if pt != 0:
             new_terms.append(pt)
     if not new_terms:
@@ -173,6 +175,14 @@ class _TNConvNd(nn.Module):
         padding_mode, bias, device, dtype, ndim, is_transposed, output_padding
         mode (str): 'base' (SymPy+InnerProduct) or 'legacy' (eval-based)
         symbolic_expression (str): expression defining aggregation.
+        already_parametrized (bool): Only effective when mode='base'.
+            If True, the expression is assumed to already contain parameter symbols
+            (e.g., w1, c1). In this case, no extra coefficient 'c' will be automatically
+            added to inner product terms, regardless of whether new weight symbols are
+            generated during parameterization.
+            If False, the original logic applies: an extra coefficient 'c' is added
+            only when no new weight symbol is generated.
+            Default: False.
     """
     __constants__ = ['in_channels', 'out_channels', 'groups', 'kernel_size',
                      'stride', 'padding', 'dilation', 'padding_mode',
@@ -194,7 +204,8 @@ class _TNConvNd(nn.Module):
                  ndim: int = 2,
                  is_transposed: bool = False,
                  output_padding: Union[int, Tuple[int, ...]] = 0,
-                 mode: str = 'base'):
+                 mode: str = 'base',
+                 already_parametrized: bool = False):
         super().__init__()
         self.ndim = ndim
         self.in_channels = int(in_channels)
@@ -202,6 +213,7 @@ class _TNConvNd(nn.Module):
         self.groups = int(groups)
         self.is_transposed = is_transposed
         self.mode = mode.lower()
+        self.already_parametrized = already_parametrized
         if self.mode not in ('base', 'legacy'):
             raise ValueError("mode must be 'base' or 'legacy'")
 
@@ -232,7 +244,7 @@ class _TNConvNd(nn.Module):
             converted_str = convert_pretty_to_innerproduct(symbolic_expression)
             raw_expr = sympify(converted_str, locals={'InnerProduct': InnerProduct})
             raw_expr = expand(simplify(raw_expr))
-            self.param_expr = parameterize_expression_conv(raw_expr)
+            self.param_expr = parameterize_expression_conv(raw_expr, already_parametrized=already_parametrized)
 
             x_sym = symbols('x')
             all_symbols = self.param_expr.free_symbols if self.param_expr != 0 else set()
@@ -337,6 +349,8 @@ class _TNConvNd(nn.Module):
             s += f', symbolic_expression="{self.symbolic_expression}"'
         if self.mode != 'base':
             s += f', mode="{self.mode}"'
+        if self.already_parametrized != False:
+            s += f', already_parametrized={self.already_parametrized}'
         return s
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -472,11 +486,12 @@ class TNConv1d(_TNConvNd):
                  padding_mode: Literal['zeros', 'reflect', 'replicate', 'circular'] = 'zeros',
                  bias: bool = True,
                  device=None, dtype=None,
-                 mode: str = 'base'):
+                 mode: str = 'base',
+                 already_parametrized: bool = False):
         super().__init__(in_channels, out_channels, kernel_size, stride, padding,
                          symbolic_expression, groups, dilation, padding_mode,
                          bias, device, dtype, ndim=1, is_transposed=False,
-                         output_padding=0, mode=mode)
+                         output_padding=0, mode=mode, already_parametrized=already_parametrized)
 
 
 class TNConv2d(_TNConvNd):
@@ -489,11 +504,12 @@ class TNConv2d(_TNConvNd):
                  padding_mode: Literal['zeros', 'reflect', 'replicate', 'circular'] = 'zeros',
                  bias: bool = True,
                  device=None, dtype=None,
-                 mode: str = 'base'):
+                 mode: str = 'base',
+                 already_parametrized: bool = False):
         super().__init__(in_channels, out_channels, kernel_size, stride, padding,
                          symbolic_expression, groups, dilation, padding_mode,
                          bias, device, dtype, ndim=2, is_transposed=False,
-                         output_padding=0, mode=mode)
+                         output_padding=0, mode=mode, already_parametrized=already_parametrized)
 
 
 class TNConv3d(_TNConvNd):
@@ -506,11 +522,12 @@ class TNConv3d(_TNConvNd):
                  padding_mode: Literal['zeros', 'reflect', 'replicate', 'circular'] = 'zeros',
                  bias: bool = True,
                  device=None, dtype=None,
-                 mode: str = 'base'):
+                 mode: str = 'base',
+                 already_parametrized: bool = False):
         super().__init__(in_channels, out_channels, kernel_size, stride, padding,
                          symbolic_expression, groups, dilation, padding_mode,
                          bias, device, dtype, ndim=3, is_transposed=False,
-                         output_padding=0, mode=mode)
+                         output_padding=0, mode=mode, already_parametrized=already_parametrized)
 
 
 # ========== Transposed convolution classes ==========
@@ -524,11 +541,12 @@ class TNConvTranspose1d(_TNConvNd):
                  dilation: Union[int, Tuple[int]] = 1,
                  bias: bool = True,
                  device=None, dtype=None,
-                 mode: str = 'base'):
+                 mode: str = 'base',
+                 already_parametrized: bool = False):
         super().__init__(in_channels, out_channels, kernel_size, stride, padding,
                          symbolic_expression, groups, dilation, 'zeros',
                          bias, device, dtype, ndim=1, is_transposed=True,
-                         output_padding=output_padding, mode=mode)
+                         output_padding=output_padding, mode=mode, already_parametrized=already_parametrized)
 
 
 class TNConvTranspose2d(_TNConvNd):
@@ -541,11 +559,12 @@ class TNConvTranspose2d(_TNConvNd):
                  dilation: Union[int, Tuple[int, int]] = 1,
                  bias: bool = True,
                  device=None, dtype=None,
-                 mode: str = 'base'):
+                 mode: str = 'base',
+                 already_parametrized: bool = False):
         super().__init__(in_channels, out_channels, kernel_size, stride, padding,
                          symbolic_expression, groups, dilation, 'zeros',
                          bias, device, dtype, ndim=2, is_transposed=True,
-                         output_padding=output_padding, mode=mode)
+                         output_padding=output_padding, mode=mode, already_parametrized=already_parametrized)
 
 
 class TNConvTranspose3d(_TNConvNd):
@@ -558,8 +577,9 @@ class TNConvTranspose3d(_TNConvNd):
                  dilation: Union[int, Tuple[int, int, int]] = 1,
                  bias: bool = True,
                  device=None, dtype=None,
-                 mode: str = 'base'):
+                 mode: str = 'base',
+                 already_parametrized: bool = False):
         super().__init__(in_channels, out_channels, kernel_size, stride, padding,
                          symbolic_expression, groups, dilation, 'zeros',
                          bias, device, dtype, ndim=3, is_transposed=True,
-                         output_padding=output_padding, mode=mode)
+                         output_padding=output_padding, mode=mode, already_parametrized=already_parametrized)

--- a/tnlearn/modules/TNlinear.py
+++ b/tnlearn/modules/TNlinear.py
@@ -1,5 +1,5 @@
 """
-Linear layer with symbolic aggregation supporting inner‑product cross terms.
+Linear layer with symbolic aggregation supporting inner-product cross terms.
 
 This module provides a fully connected layer where the aggregation function is defined
 by a symbolic expression. Two modes are supported:
@@ -167,6 +167,14 @@ class TNLinear(nn.Module):
         device (torch.device, optional): Device for parameters.
         dtype (torch.dtype, optional): Data type for parameters.
         mode (str): 'base' or 'legacy'. Default 'base'.
+        already_parametrized (bool): Only effective when mode='base'.
+            If True, the expression is assumed to already contain parameter symbols
+            (e.g., w1, c1). In this case, no extra coefficient 'c' will be automatically
+            added to inner product terms, regardless of whether new weight symbols are
+            generated during parameterization.
+            If False, the original logic applies: an extra coefficient 'c' is added
+            only when no new weight symbol is generated.
+            Default: False.
     """
     def __init__(self,
                  in_features: int,
@@ -175,7 +183,9 @@ class TNLinear(nn.Module):
                  bias: bool = True,
                  device=None,
                  dtype=None,
-                 mode: str = 'base'):
+                 mode: str = 'base',
+                 already_parametrized: bool = False
+                    ):
         super().__init__()
         self.in_features = int(in_features)
         self.out_features = int(out_features)
@@ -184,6 +194,7 @@ class TNLinear(nn.Module):
         self.device = device
         self.dtype = dtype
         self.mode = mode.lower()
+        self.already_parametrized = already_parametrized
         if self.mode not in ('base', 'legacy'):
             raise ValueError("mode must be 'base' or 'legacy'")
 
@@ -193,7 +204,8 @@ class TNLinear(nn.Module):
             converted_str = convert_pretty_to_innerproduct(symbolic_expression)
             raw_expr = sympify(converted_str, locals={'InnerProduct': InnerProduct})
             raw_expr = expand(simplify(raw_expr))
-            self.param_expr = parameterize_expression(raw_expr, include_bias=False)
+            self.param_expr = parameterize_expression(raw_expr, include_bias=False,
+                                                      already_parametrized=already_parametrized)
 
             # 2. Extract symbols: w_i (weights) and c_i (coefficients)
             all_symbols = self.param_expr.free_symbols if self.param_expr != 0 else set()
@@ -322,7 +334,8 @@ class TNLinear(nn.Module):
             converted_str = convert_pretty_to_innerproduct(self.symbolic_expression)
             raw_expr = sympify(converted_str, locals={'InnerProduct': InnerProduct})
             raw_expr = expand(simplify(raw_expr))
-            self.param_expr = parameterize_expression(raw_expr, include_bias=False)
+            self.param_expr = parameterize_expression(raw_expr, include_bias=False,
+                                                      already_parametrized=self.already_parametrized)
             self._x_sym = symbols('x')
         else:  # legacy
             # Rebuild funcs from self.terms

--- a/tnlearn/modules/TNrnn.py
+++ b/tnlearn/modules/TNrnn.py
@@ -116,7 +116,8 @@ class _TNRNNBase(nn.Module):
                  bias: bool = True, batch_first: bool = False,
                  dropout: float = 0.0, bidirectional: bool = False,
                  symbolic_expression: str = 'x',
-                 device=None, dtype=None):
+                 device=None, dtype=None,
+                 already_parametrized: bool = False):  # NEW
         super().__init__()
         self.mode = mode.lower()
         if self.mode not in ('base', 'legacy'):
@@ -133,6 +134,7 @@ class _TNRNNBase(nn.Module):
         self.symbolic_expression = symbolic_expression
         self.device = device
         self.dtype = dtype
+        self.already_parametrized = already_parametrized  # NEW
 
         self.num_directions = 2 if bidirectional else 1
         self.num_cells = num_layers * self.num_directions
@@ -155,7 +157,6 @@ class _TNRNNBase(nn.Module):
                 device=device,
                 dtype=dtype
             )
-            # For RNN, set nonlinearity if present
             if rnn_type == 'RNN' and hasattr(self, 'nonlinearity'):
                 self.rnn.nonlinearity = self.nonlinearity
 
@@ -167,7 +168,8 @@ class _TNRNNBase(nn.Module):
                 for direction in range(2 if bidirectional else 1):
                     cell = cell_factory(
                         layer_input_size, hidden_size, bias,
-                        symbolic_expression, device, dtype
+                        symbolic_expression, device, dtype,
+                        already_parametrized=already_parametrized  # NEW
                     )
                     self.cells.append(cell)
 
@@ -179,7 +181,6 @@ class _TNRNNBase(nn.Module):
         self.reset_parameters()
 
     def reset_parameters(self) -> None:
-        """Parameters are initialised by the submodules."""
         pass
 
     def _default_initial_state(self, batch_size: int, device: torch.device):
@@ -364,10 +365,11 @@ class _TNRNNBase(nn.Module):
             s += f', symbolic_expression="{self.symbolic_expression}"'
         if self.mode != 'base':
             s += f', mode="{self.mode}"'
+        if self.already_parametrized != False:  # NEW
+            s += f', already_parametrized={self.already_parametrized}'
         return s
 
     def __getstate__(self):
-        # Remove non-picklable attributes
         state = self.__dict__.copy()
         if self.mode == 'legacy':
             state.pop('funcs', None)
@@ -386,14 +388,17 @@ class TNRNN(_TNRNNBase):
                  nonlinearity: str = 'tanh', bias: bool = True, batch_first: bool = False,
                  dropout: float = 0.0, bidirectional: bool = False,
                  symbolic_expression: str = 'x', device=None, dtype=None,
-                 mode: str = 'base'):
+                 mode: str = 'base',
+                 already_parametrized: bool = False):  # NEW
         self.nonlinearity = nonlinearity
-        def cell_factory(in_size, h_size, b, sym_expr, dev, dtyp):
+        def cell_factory(in_size, h_size, b, sym_expr, dev, dtyp, ap):  # added ap
             return TNRNNCell(in_size, h_size, bias=b, nonlinearity=nonlinearity,
-                             symbolic_expression=sym_expr, device=dev, dtype=dtyp, mode=mode)
+                             symbolic_expression=sym_expr, device=dev, dtype=dtyp, mode=mode,
+                             already_parametrized=ap)  # pass ap
         super().__init__(cell_factory, mode, 'RNN', input_size, hidden_size, num_layers,
                          bias, batch_first, dropout, bidirectional,
-                         symbolic_expression, device, dtype)
+                         symbolic_expression, device, dtype,
+                         already_parametrized=already_parametrized)  # NEW
 
 
 class TNLSTM(_TNRNNBase):
@@ -401,13 +406,16 @@ class TNLSTM(_TNRNNBase):
                  bias: bool = True, batch_first: bool = False,
                  dropout: float = 0.0, bidirectional: bool = False,
                  symbolic_expression: str = 'x', device=None, dtype=None,
-                 mode: str = 'base'):
-        def cell_factory(in_size, h_size, b, sym_expr, dev, dtyp):
+                 mode: str = 'base',
+                 already_parametrized: bool = False):  # NEW
+        def cell_factory(in_size, h_size, b, sym_expr, dev, dtyp, ap):  # added ap
             return TNLSTMCell(in_size, h_size, bias=b,
-                              symbolic_expression=sym_expr, device=dev, dtype=dtyp, mode=mode)
+                              symbolic_expression=sym_expr, device=dev, dtype=dtyp, mode=mode,
+                              already_parametrized=ap)  # pass ap
         super().__init__(cell_factory, mode, 'LSTM', input_size, hidden_size, num_layers,
                          bias, batch_first, dropout, bidirectional,
-                         symbolic_expression, device, dtype)
+                         symbolic_expression, device, dtype,
+                         already_parametrized=already_parametrized)  # NEW
 
 
 class TNGRU(_TNRNNBase):
@@ -415,13 +423,16 @@ class TNGRU(_TNRNNBase):
                  bias: bool = True, batch_first: bool = False,
                  dropout: float = 0.0, bidirectional: bool = False,
                  symbolic_expression: str = 'x', device=None, dtype=None,
-                 mode: str = 'base'):
-        def cell_factory(in_size, h_size, b, sym_expr, dev, dtyp):
+                 mode: str = 'base',
+                 already_parametrized: bool = False):  # NEW
+        def cell_factory(in_size, h_size, b, sym_expr, dev, dtyp, ap):  # added ap
             return TNGRUCell(in_size, h_size, bias=b,
-                             symbolic_expression=sym_expr, device=dev, dtype=dtyp, mode=mode)
+                             symbolic_expression=sym_expr, device=dev, dtype=dtyp, mode=mode,
+                             already_parametrized=ap)  # pass ap
         super().__init__(cell_factory, mode, 'GRU', input_size, hidden_size, num_layers,
                          bias, batch_first, dropout, bidirectional,
-                         symbolic_expression, device, dtype)
+                         symbolic_expression, device, dtype,
+                         already_parametrized=already_parametrized)  # NEW
 
 
 # ---------- Public alias for backward compatibility ----------
@@ -436,7 +447,8 @@ class TNRNNCellBase(nn.Module):
 
     def __init__(self, input_size: int, hidden_size: int, bias: bool,
                  symbolic_expression: str = 'x', num_chunks: int = 1,
-                 device=None, dtype=None, mode: str = 'base'):
+                 device=None, dtype=None, mode: str = 'base',
+                 already_parametrized: bool = False):  # NEW
         super().__init__()
         self.input_size = input_size
         self.hidden_size = hidden_size
@@ -444,6 +456,7 @@ class TNRNNCellBase(nn.Module):
         self.symbolic_expression = symbolic_expression
         self.num_chunks = num_chunks
         self.mode = mode.lower()
+        self.already_parametrized = already_parametrized  # NEW
 
         self.ih = TNLinear(
             in_features=input_size,
@@ -452,7 +465,8 @@ class TNRNNCellBase(nn.Module):
             bias=bias,
             device=device,
             dtype=dtype,
-            mode=mode
+            mode=mode,
+            already_parametrized=already_parametrized  # NEW
         )
         self.hh = TNLinear(
             in_features=hidden_size,
@@ -461,7 +475,8 @@ class TNRNNCellBase(nn.Module):
             bias=bias,
             device=device,
             dtype=dtype,
-            mode=mode
+            mode=mode,
+            already_parametrized=already_parametrized  # NEW
         )
         self.reset_parameters()
 
@@ -476,15 +491,19 @@ class TNRNNCellBase(nn.Module):
             s += f', symbolic_expression={self.symbolic_expression}'
         if self.mode != 'base':
             s += f', mode={self.mode}'
+        if self.already_parametrized != False:  # NEW
+            s += f', already_parametrized={self.already_parametrized}'
         return s
 
 
 class TNRNNCell(TNRNNCellBase):
     def __init__(self, input_size: int, hidden_size: int, bias: bool = True,
                  nonlinearity: str = 'tanh', symbolic_expression: str = 'x',
-                 device=None, dtype=None, mode: str = 'base'):
+                 device=None, dtype=None, mode: str = 'base',
+                 already_parametrized: bool = False):  # NEW
         super().__init__(input_size, hidden_size, bias, symbolic_expression,
-                         num_chunks=1, device=device, dtype=dtype, mode=mode)
+                         num_chunks=1, device=device, dtype=dtype, mode=mode,
+                         already_parametrized=already_parametrized)  # NEW
         self.nonlinearity = nonlinearity
 
     def forward(self, input: Tensor, hx: Optional[Tensor] = None) -> Tensor:
@@ -516,9 +535,11 @@ class TNRNNCell(TNRNNCellBase):
 class TNLSTMCell(TNRNNCellBase):
     def __init__(self, input_size: int, hidden_size: int, bias: bool = True,
                  symbolic_expression: str = 'x', device=None, dtype=None,
-                 mode: str = 'base'):
+                 mode: str = 'base',
+                 already_parametrized: bool = False):  # NEW
         super().__init__(input_size, hidden_size, bias, symbolic_expression,
-                         num_chunks=4, device=device, dtype=dtype, mode=mode)
+                         num_chunks=4, device=device, dtype=dtype, mode=mode,
+                         already_parametrized=already_parametrized)  # NEW
 
     def forward(self, input: Tensor, hx: Optional[Tuple[Tensor, Tensor]] = None) -> Tuple[Tensor, Tensor]:
         is_batched = input.dim() == 2
@@ -558,9 +579,11 @@ class TNLSTMCell(TNRNNCellBase):
 class TNGRUCell(TNRNNCellBase):
     def __init__(self, input_size: int, hidden_size: int, bias: bool = True,
                  symbolic_expression: str = 'x', device=None, dtype=None,
-                 mode: str = 'base'):
+                 mode: str = 'base',
+                 already_parametrized: bool = False):  # NEW
         super().__init__(input_size, hidden_size, bias, symbolic_expression,
-                         num_chunks=3, device=device, dtype=dtype, mode=mode)
+                         num_chunks=3, device=device, dtype=dtype, mode=mode,
+                         already_parametrized=already_parametrized)  # NEW
 
     def forward(self, input: Tensor, hx: Optional[Tensor] = None) -> Tensor:
         is_batched = input.dim() == 2

--- a/tnlearn/modules/TNtransformer.py
+++ b/tnlearn/modules/TNtransformer.py
@@ -106,6 +106,7 @@ class TNTransformerEncoderLayer(Module):
         bias: if False, linear and LayerNorm layers have no bias (default=True).
         symbolic_expression: symbolic expression for TNLinear (default='x').
         mode: 'base' or 'legacy' (default='base').
+        already_parametrized: bool, passed to TNLinear (default=False).
         device, dtype: factory kwargs.
     """
     __constants__ = ['norm_first']
@@ -123,24 +124,27 @@ class TNTransformerEncoderLayer(Module):
             bias: bool = True,
             symbolic_expression: str = 'x',
             mode: str = 'base',
+            already_parametrized: bool = False,  # NEW
             device=None,
             dtype=None
     ) -> None:
         factory_kwargs = {'device': device, 'dtype': dtype}
         super().__init__()
         self.mode = mode.lower()
+        self.already_parametrized = already_parametrized  # NEW
         self.self_attn = MultiheadAttention(
             d_model, nhead, dropout=dropout,
             bias=bias, batch_first=batch_first,
             **factory_kwargs
         )
 
-        # Replace Linear with TNLinear, passing mode
+        # Replace Linear with TNLinear, passing mode and already_parametrized
         self.linear1 = TNLinear(
             d_model, dim_feedforward,
             symbolic_expression=symbolic_expression,
             bias=bias,
             mode=self.mode,
+            already_parametrized=already_parametrized,  # NEW
             **factory_kwargs
         )
         self.dropout = Dropout(dropout)
@@ -149,6 +153,7 @@ class TNTransformerEncoderLayer(Module):
             symbolic_expression=symbolic_expression,
             bias=bias,
             mode=self.mode,
+            already_parametrized=already_parametrized,  # NEW
             **factory_kwargs
         )
 
@@ -308,6 +313,7 @@ class TNTransformerDecoderLayer(Module):
         bias: if False, linear and LayerNorm layers have no bias (default=True).
         symbolic_expression: symbolic expression for TNLinear (default='x').
         mode: 'base' or 'legacy' (default='base').
+        already_parametrized: bool, passed to TNLinear (default=False).
         device, dtype: factory kwargs.
     """
     __constants__ = ['norm_first']
@@ -325,12 +331,14 @@ class TNTransformerDecoderLayer(Module):
             bias: bool = True,
             symbolic_expression: str = 'x',
             mode: str = 'base',
+            already_parametrized: bool = False,  # NEW
             device=None,
             dtype=None
     ) -> None:
         factory_kwargs = {'device': device, 'dtype': dtype}
         super().__init__()
         self.mode = mode.lower()
+        self.already_parametrized = already_parametrized  # NEW
         self.self_attn = MultiheadAttention(
             d_model, nhead, dropout=dropout,
             batch_first=batch_first, bias=bias,
@@ -347,6 +355,7 @@ class TNTransformerDecoderLayer(Module):
             symbolic_expression=symbolic_expression,
             bias=bias,
             mode=self.mode,
+            already_parametrized=already_parametrized,  # NEW
             **factory_kwargs
         )
         self.dropout = Dropout(dropout)
@@ -355,6 +364,7 @@ class TNTransformerDecoderLayer(Module):
             symbolic_expression=symbolic_expression,
             bias=bias,
             mode=self.mode,
+            already_parametrized=already_parametrized,  # NEW
             **factory_kwargs
         )
 
@@ -629,6 +639,7 @@ class TNTransformer(Module):
         bias: if False, linear and LayerNorm layers have no bias (default=True).
         symbolic_expression: symbolic expression for TNLinear (default='x').
         mode: 'base' or 'legacy' (default='base').
+        already_parametrized: bool, passed to TNLinear (default=False).
         device, dtype: factory kwargs.
     """
     def __init__(
@@ -648,6 +659,7 @@ class TNTransformer(Module):
             bias: bool = True,
             symbolic_expression: str = 'x',
             mode: str = 'base',
+            already_parametrized: bool = False,  # NEW
             device=None,
             dtype=None
     ) -> None:
@@ -661,7 +673,9 @@ class TNTransformer(Module):
             encoder_layer = TNTransformerEncoderLayer(
                 d_model, nhead, dim_feedforward, dropout,
                 activation, layer_norm_eps, batch_first, norm_first,
-                bias, symbolic_expression, mode, **factory_kwargs
+                bias, symbolic_expression, mode,
+                already_parametrized=already_parametrized,  # NEW
+                **factory_kwargs
             )
             encoder_norm = LayerNorm(d_model, eps=layer_norm_eps, bias=bias, **factory_kwargs)
             self.encoder = TNTransformerEncoder(encoder_layer, num_encoder_layers, encoder_norm)
@@ -672,7 +686,9 @@ class TNTransformer(Module):
             decoder_layer = TNTransformerDecoderLayer(
                 d_model, nhead, dim_feedforward, dropout,
                 activation, layer_norm_eps, batch_first, norm_first,
-                bias, symbolic_expression, mode, **factory_kwargs
+                bias, symbolic_expression, mode,
+                already_parametrized=already_parametrized,  # NEW
+                **factory_kwargs
             )
             decoder_norm = LayerNorm(d_model, eps=layer_norm_eps, bias=bias, **factory_kwargs)
             self.decoder = TNTransformerDecoder(decoder_layer, num_decoder_layers, decoder_norm)

--- a/tnlearn/operator/inner_product.py
+++ b/tnlearn/operator/inner_product.py
@@ -1,10 +1,39 @@
-# operator/inner_product.py
+"""
+InnerProduct operator and parameterization utilities for symbolic expressions.
+
+This module provides:
+- InnerProduct class: a symbolic representation of the inner product <a, b>.
+- Functions to convert between pretty-printed and InnerProduct forms.
+- Parameterization of expressions: replacing numeric constants and known symbols
+  with learnable parameters (w, c, b), with an option to suppress automatic
+  coefficient addition for already-parameterized expressions.
+
+Copyright (c) 2024 Meng WANG. All Rights Reserved.
+Copyright (c) 2026 Tieyun LI. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 from sympy import Expr, Add, Mul, sympify, symbols, Symbol, Number, Pow, sin, cos, exp
 import re
 import numpy as np
 import torch
 
+
 class InnerProduct(Expr):
+    """
+    Symbolic representation of an inner product <left, right>.
+    """
     def __new__(cls, left, right, **kwargs):
         left = sympify(left)
         right = sympify(right)
@@ -67,7 +96,6 @@ def _simplify_expr(expr, **kwargs):
             if e.is_Mul:
                 coeff, rest = e.as_coeff_Mul()
                 if coeff < 0:
-                    # Extract negative sign, core becomes the positive coefficient part
                     return -1, Mul(-coeff, rest)
                 else:
                     return 1, e
@@ -78,7 +106,7 @@ def _simplify_expr(expr, **kwargs):
 
         sign_left, core_left = extract_sign(left)
         sign_right, core_right = extract_sign(right)
-        total_sign = sign_left * sign_right  # 1 or -1
+        total_sign = sign_left * sign_right
 
         inner = InnerProduct(core_left, core_right)
         expanded = inner._eval_expand_basic(**kwargs)
@@ -111,6 +139,7 @@ def _simplify_expr(expr, **kwargs):
 
 
 def convert_pretty_to_innerproduct(expr_str):
+    """Convert pretty-printed <...> expressions to InnerProduct(...) function calls."""
     pattern = r'<([^<>]+)>'
     def repl(match):
         inner = match.group(1).strip()
@@ -119,15 +148,15 @@ def convert_pretty_to_innerproduct(expr_str):
         expr_str = re.sub(pattern, repl, expr_str)
     return expr_str
 
+
 def convert_innerproduct_to_pretty(expr_str: str) -> str:
     """
     Convert InnerProduct(...) and IP(...) to pretty <...> format.
-    
+
     Example:
         "InnerProduct(w, x**2) + IP(c, x)" -> "<w, x**2> + <c, x>"
     """
     expr_str = re.sub(r'\bIP\s*\(', 'InnerProduct(', expr_str)
-    # replace InnerProduct(...) with <...>，aavailable for <<*,*>,*>
     pattern = r'InnerProduct\s*\(([^()]*)\)'
     while re.search(pattern, expr_str):
         expr_str = re.sub(pattern, r'<\1>', expr_str)
@@ -135,10 +164,14 @@ def convert_innerproduct_to_pretty(expr_str: str) -> str:
 
 
 def is_inner_product(expr):
+    """Check if an expression is an InnerProduct instance."""
     return isinstance(expr, InnerProduct)
 
 
 def replace_numbers(expr, counter, in_exponent=False):
+    """
+    Replace numeric constants with new weight symbols (w_i).
+    """
     if isinstance(expr, Symbol):
         return expr
     if expr.is_Number:
@@ -165,7 +198,21 @@ def replace_numbers(expr, counter, in_exponent=False):
         return expr
 
 
-def parameterize_term(term, counter, include_bias=False):
+def parameterize_term(term, counter, include_bias=False, already_parametrized=True):
+    """
+    Parameterize a single term of an expression.
+
+    Args:
+        term: a SymPy expression (single term, not an Add)
+        counter: dict with keys 'w', 'c', 'b' to keep track of parameter indices
+        include_bias: if True, replace standalone numeric constants with b_i
+        already_parametrized: if True, do NOT add an extra coefficient 'c'
+            even if no new weight symbol is generated. This is useful when the
+            expression already contains parameter symbols (e.g., w1, c1, b1).
+            If False, the original logic applies: add 'c' only when no new
+            weight symbol is introduced.
+            Default: True.
+    """
     if term.is_number:
         if include_bias:
             b = symbols('b%d' % counter['b'])
@@ -180,9 +227,13 @@ def parameterize_term(term, counter, include_bias=False):
         new_a2 = replace_numbers(a2, counter, False)
         new_ip = InnerProduct(new_a1, new_a2)
         if counter['w'] == old_w:
-            c = symbols('c%d' % counter['c'])
-            counter['c'] += 1
-            return Mul(c, new_ip)
+            # No new weight generated; add 'c' only if not already_parametrized
+            if not already_parametrized:
+                c = symbols('c%d' % counter['c'])
+                counter['c'] += 1
+                return Mul(c, new_ip)
+            else:
+                return new_ip
         return new_ip
     if isinstance(term, Mul):
         inner_products = []
@@ -214,18 +265,32 @@ def parameterize_term(term, counter, include_bias=False):
         if not inner_products:
             return 1
         result = Mul(*inner_products) if len(inner_products) > 1 else inner_products[0]
-        if not created_param:
+        if not created_param and not already_parametrized:
+            # Only add 'c' if no new weight was generated and we are not already parameterized
             c = symbols('c%d' % counter['c'])
             counter['c'] += 1
             result = Mul(c, result)
         return result
+    # For other cases (e.g., a simple symbol or function)
     new_expr = replace_numbers(term, counter, False)
     w = symbols('w%d' % counter['w'])
     counter['w'] += 1
+    # A new weight is always generated here, so no 'c' needed regardless of already_parametrized
     return InnerProduct(w, new_expr)
 
 
-def parameterize_expression(expr, include_bias=False):
+def parameterize_expression(expr, include_bias=False, already_parametrized=True):
+    """
+    Parameterize an entire expression by replacing constants and known symbols with learnable parameters.
+
+    Args:
+        expr: a SymPy expression (possibly an Add of multiple terms)
+        include_bias: whether to replace standalone constants with b_i
+        already_parametrized: passed to parameterize_term; controls automatic addition
+            of extra coefficients 'c'. Default: True.
+    Returns:
+        A new SymPy expression with parameters.
+    """
     if isinstance(expr, Add):
         terms = list(expr.args)
     else:
@@ -233,7 +298,7 @@ def parameterize_expression(expr, include_bias=False):
     counter = {'w': 1, 'c': 1, 'b': 1}
     new_terms = []
     for t in terms:
-        pt = parameterize_term(t, counter, include_bias)
+        pt = parameterize_term(t, counter, include_bias, already_parametrized)
         if pt != 0:
             new_terms.append(pt)
     if not new_terms:
@@ -242,6 +307,11 @@ def parameterize_expression(expr, include_bias=False):
 
 
 def inner_product(a, b, N=None):
+    """
+    Compute the inner product (sum of elementwise products) for numpy or torch tensors.
+
+    Supports broadcasting and reshaping to handle batched inputs.
+    """
     is_torch = isinstance(a, torch.Tensor) or isinstance(b, torch.Tensor)
     if is_torch:
         a = torch.as_tensor(a) if not isinstance(a, torch.Tensor) else a
@@ -316,6 +386,9 @@ def inner_product(a, b, N=None):
 
 
 def eval_sympy_expr(expr, subs):
+    """
+    Evaluate a SymPy expression with torch tensors as substitutions.
+    """
     if expr.is_Number:
         device = next(iter(subs.values())).device
         return torch.tensor(float(expr), device=device)
@@ -348,6 +421,9 @@ def eval_sympy_expr(expr, subs):
 
 
 def evaluate_expression(expr, x_tensor, param_dict, out_dim):
+    """
+    Evaluate a parameterized expression for a batch of inputs and all output neurons.
+    """
     batch = x_tensor.size(0)
     results = []
     x_sym = symbols('x')
@@ -426,7 +502,6 @@ def neuronseek_config_to_string(config: dict) -> str:
         ...
         TypeError: 'pure_indices' must be a list
     """
-
     # ---- Safely retrieve and validate fields ----
     pure = config.get('pure_indices')
     if pure is None:
@@ -440,7 +515,6 @@ def neuronseek_config_to_string(config: dict) -> str:
     if not isinstance(inter, list):
         raise TypeError("'interact_indices' must be a list")
 
-    # ---- Filter valid orders (positive integers) ----
     def is_valid_order(v: any) -> bool:
         """Return True if v is a positive integer."""
         try:
@@ -451,7 +525,6 @@ def neuronseek_config_to_string(config: dict) -> str:
     pure = [k for k in pure if is_valid_order(k)]
     inter = [m for m in inter if is_valid_order(m)]
 
-    # ---- Warn about unsupported interaction_form ----
     form = config.get('interaction_form', 'cp_inner_product')
     if form != 'cp_inner_product':
         import warnings
@@ -461,11 +534,9 @@ def neuronseek_config_to_string(config: dict) -> str:
             UserWarning
         )
 
-    # ---- Build expression parts ----
     parts = []
-    w_idx = 1   # weight vector counter
+    w_idx = 1
 
-    # Polynomial stream: each order k gives <w_i, x> (if k=1) or <w_i, x**k>
     for k in pure:
         if k == 1:
             parts.append(f"<w{w_idx}, x>")
@@ -473,7 +544,6 @@ def neuronseek_config_to_string(config: dict) -> str:
             parts.append(f"<w{w_idx}, x**{k}>")
         w_idx += 1
 
-    # Interaction stream: each order m gives product of m linear inner products
     for m in inter:
         factors = []
         for _ in range(m):
@@ -481,7 +551,6 @@ def neuronseek_config_to_string(config: dict) -> str:
             w_idx += 1
         parts.append("*".join(factors))
 
-    # Periodic stream: if enabled, add <w_i, sin(x)>
     if config.get('periodic', False):
         parts.append(f"<w{w_idx}, sin(x)>")
         w_idx += 1
@@ -489,4 +558,5 @@ def neuronseek_config_to_string(config: dict) -> str:
     return "+".join(parts)
 
 
+# Alias for convenience
 IP = InnerProduct


### PR DESCRIPTION
- Add already_parametrized parameter to MLPRegressor and MLPClassifier
- Control automatic addition of coefficient in parameterization
- Update inner_product.parameterize_expression to respect the flag
- Propagate already_parametrized flag to all modules
- Add corresponding tests and update test files