### PR TITLE
Add NeuronSeek search with rank-preserving inner-product export

### DIFF
--- a/.github/workflows/neuronseek.yml
+++ b/.github/workflows/neuronseek.yml
@@ -1,0 +1,35 @@
+name: NeuronSeek regression tests
+
+on:
+  push:
+    branches: [codex/neuronseek-inner-product]
+  pull_request:
+    paths:
+      - 'tnlearn/**'
+      - 'tests/test_neuronseek.py'
+      - '.github/workflows/neuronseek.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  neuronseek:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.12']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install CPU dependencies
+        run: |
+          python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+          python -m pip install . pytest
+      - name: Test structure export and MLP integration
+        env:
+          MPLBACKEND: Agg
+        run: python -m pytest tests/test_neuronseek.py -q

--- a/.github/workflows/neuronseek.yml
+++ b/.github/workflows/neuronseek.yml
@@ -2,7 +2,7 @@ name: NeuronSeek regression tests
 
 on:
   push:
-    branches: [codex/neuronseek-inner-product]
+    branches: [main, codex/neuronseek-inner-product]
   pull_request:
     paths:
       - 'tnlearn/**'

--- a/README.md
+++ b/README.md
@@ -145,30 +145,52 @@ clf.fit(X_train, y_train)
 clf.predict(X_test)
 ```
 
-Another quick example to show you how to use polynomial tensor regressor to build neurons:
+Use NeuronSeek to search pure polynomial and CP interaction orders, then build
+an MLP from the exported inner-product expression:
 
 ```python
-from tnlearn import PolyTensorRegression
+from tnlearn import PolyTensorRegressor
 from tnlearn import MLPRegressor
+from tnlearn.operator.inner_product import neuronseek_config_to_string
 from sklearn.datasets import make_regression
 from sklearn.model_selection import train_test_split
 
 # Generate data.
-X, y = make_regression(n_samples=200, random_state=1)
+X, y = make_regression(n_samples=200, n_features=10, random_state=1)
 X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=1)
 
-# A polynomial tensor regressor is used to generate task-based neurons.
-neuron = PolyTensorRegression()
+# Search the structure; the MLP will learn its own weights.
+neuron = PolyTensorRegressor(rank=3, poly_order=3, random_state=1)
 neuron.fit(X_train, y_train)
+print(neuron.structure_)
+print(neuron.neuron)
+assert neuron.neuron == (neuronseek_config_to_string(neuron.structure_) or '0')
 
-# Build neural network using task-based neurons and train it.
-clf = MLPRegressor(neurons=neuron.neuron，
-                   layers_list=[50,30,10]) #Specify the structure of the hidden layers in the MLP.
+# The default base mode understands inner products.
+clf = MLPRegressor(neurons=neuron.neuron, layers_list=[50, 30, 10])
 clf.fit(X_train, y_train)
 
 # Predict
 clf.predict(X_test)
 ```
+
+`pure_indices` and `interact_indices` are polynomial **orders**, not feature
+indices. A pure order 2 exports `<w1, x**2>`, while an interaction order 2
+exports `<w1, x>*<w2, x>`. Each interaction order exports a sum of `rank`
+independent CP components; omitting `rank` in a manual configuration defaults
+to 1. Fitted search weights, gates and batch-normalization parameters are not
+transferred to the MLP. If all gates are pruned, the searcher exports `'0'`,
+which produces bias-only custom layers.
+
+All export paths, including `track_callback` and `get_significant_polynomial()`,
+use `neuronseek_config_to_string`. Manual configurations may also include
+`periodic=True` to add `<w, sin(x)>`; this searcher selects polynomial orders
+only. `PolyTensorRegressor` supports CP search; the existing
+`PolyTensorRegression` remains the separate legacy CP/Tucker implementation.
+
+After installing pytest, run the focused regression checks with
+`python -m pytest tests/test_neuronseek.py`. The four manual configurations are
+also available in `examples/example_neuronseek_configs.py`.
 
 ## DrSR: LLM-based Symbolic Regression
 

--- a/examples/Poly_demo.py
+++ b/examples/Poly_demo.py
@@ -1,25 +1,26 @@
-from Poly_tensor_regressor import PolynomialTensorRegression
-import numpy as np
+"""Search a NeuronSeek structure and pass its expression to the base MLP."""
 
-decomp_rank = 3  # Decomposition rank
-poly_order = 3  # Polynomial order
-net_dims = (64, 32)  # Network layer dimensions
-reg_lambda = 0.01  # Regularization strength
+from sklearn.datasets import make_regression
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import StandardScaler
 
-np.random.seed(42)
+from tnlearn import MLPRegressor, PolyTensorRegressor
+from tnlearn.operator.inner_product import neuronseek_config_to_string
 
-X = np.random.rand(100, 3, 2)
-X = (X - np.mean(X, axis=0)) / np.std(X, axis=0)
-y = np.random.rand(100)
-reg_lambda_w = 0.1
-reg_lambda_c = 0.1
-losses = []
 
-neuron = PolynomialTensorRegression(decomp_rank, 
-                                    poly_order, 
-                                    method='cp', 
-                                    reg_lambda_w=0.01, 
-                                    reg_lambda_c=0.01) 
+if __name__ == '__main__':
+    X, y = make_regression(n_samples=100, n_features=10, noise=0.1, random_state=1)
+    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=1)
+    scaler = StandardScaler().fit(X_train)
+    X_train, X_test = scaler.transform(X_train), scaler.transform(X_test)
 
-neuron.fit(X,y)
-print(neuron.neuron)
+    search = PolyTensorRegressor(rank=3, poly_order=3, num_epochs=30, random_state=1)
+    search.fit(X_train, y_train)
+    neuron = neuronseek_config_to_string(search.structure_) or '0'
+    assert neuron == search.neuron
+    print('Structure:', search.structure_)
+    print('Neuron:', neuron)
+
+    mlp = MLPRegressor(neuron, layers_list=[10], max_iter=100)
+    mlp.fit(X_train, y_train)
+    print('Test R2:', mlp.score(X_test, y_test))

--- a/examples/example_neuronseek_configs.py
+++ b/examples/example_neuronseek_configs.py
@@ -1,0 +1,28 @@
+"""Fit the four manual configurations using MLPRegressor's default settings."""
+
+import numpy as np
+from sklearn.datasets import make_regression
+
+from tnlearn import MLPRegressor
+from tnlearn.operator.inner_product import neuronseek_config_to_string
+
+
+if __name__ == '__main__':
+    X, y = make_regression(n_samples=100, n_features=10, noise=0.1, random_state=1)
+    configs = [
+        dict(type='neuronseek', pure_indices=[1, 2], interact_indices=[2, 3],
+             interaction_form='cp_inner_product', rank=8),
+        dict(pure_indices=[1, 3, 5], interact_indices=[]),
+        dict(pure_indices=[], interact_indices=[2, 4]),
+        dict(pure_indices=[1, 2], interact_indices=[2], periodic=True),
+    ]
+    for index, config in enumerate(configs, 1):
+        neuron = neuronseek_config_to_string(config)
+        print(f'Neuron {index}: {neuron}', flush=True)
+        mlp = MLPRegressor(neuron)
+        mlp.fit(X, y)
+        predictions = mlp.predict(X)
+        assert predictions.shape == (100,)
+        assert np.isfinite(predictions).all()
+        assert np.isfinite(mlp.losses).all()
+        print(f'Configuration {index}: {len(mlp.losses)} iterations completed', flush=True)

--- a/tests/test_neuronseek.py
+++ b/tests/test_neuronseek.py
@@ -173,6 +173,32 @@ def test_unsupported_search_settings_are_rejected(kwargs):
         PolyTensorRegressor(**kwargs)
 
 
+@pytest.mark.parametrize('reg_lambda_w', [0.0, 0.1])
+def test_weight_regularization_is_controlled_by_reg_lambda_w(monkeypatch, reg_lambda_w):
+    initial_weights = {}
+    original_forward = SparseSearchAgent.forward
+
+    def zero_task_output(agent, *args, **kwargs):
+        initial_weights.update({name: p.detach().clone()
+                                for name, p in agent.core.named_parameters()})
+        # Keep the real forward/backward path, but eliminate task gradients.
+        return original_forward(agent, *args, **kwargs) * 0
+
+    monkeypatch.setattr(SparseSearchAgent, 'forward', zero_task_output)
+    X = np.random.default_rng(1).normal(size=(4, 3)).astype(np.float32)
+    reg = PolyTensorRegressor(rank=2, poly_order=2, num_epochs=1, batch_size=4,
+                              reg_lambda_w=reg_lambda_w, reg_lambda_c=0,
+                              learning_rate=1e-5, device='cpu', random_state=1)
+    reg.fit(X, np.zeros(4, dtype=np.float32))
+    assert initial_weights
+    for name, parameter in reg.agent.core.named_parameters():
+        before = initial_weights[name]
+        if reg_lambda_w == 0:
+            torch.testing.assert_close(parameter, before, rtol=0, atol=0)
+        else:
+            assert parameter.detach().abs().sum() < before.abs().sum()
+
+
 def test_singleton_and_misaligned_training_data_are_rejected():
     reg = PolyTensorRegressor(device='cpu')
     with pytest.raises(ValueError, match='at least two'):

--- a/tests/test_neuronseek.py
+++ b/tests/test_neuronseek.py
@@ -1,0 +1,181 @@
+"""Regression checks for NeuronSeek structure export and the base MLP API."""
+
+import numpy as np
+import pytest
+import sympy as sp
+import torch
+from sklearn.datasets import make_regression
+
+import tnlearn
+from tnlearn import MLPRegressor, PolyTensorRegression, PolyTensorRegressor
+from tnlearn.mlpregressor import BaseCustomNeuronLayer
+from tnlearn.operator.inner_product import (
+    InnerProduct,
+    convert_pretty_to_innerproduct,
+    neuronseek_config_to_string,
+)
+from tnlearn.poly_regressor import SparseSearchAgent
+
+
+CONFIGS = [
+    dict(type='neuronseek', pure_indices=[1, 2], interact_indices=[2, 3],
+         interaction_form='cp_inner_product', rank=8),
+    dict(pure_indices=[1, 3, 5], interact_indices=[]),
+    dict(pure_indices=[], interact_indices=[2, 4]),
+    dict(pure_indices=[1, 2], interact_indices=[2], periodic=True),
+]
+
+
+@pytest.fixture(autouse=True)
+def small_cpu_tests():
+    previous = torch.get_num_threads()
+    torch.set_num_threads(1)
+    yield
+    torch.set_num_threads(previous)
+
+
+def test_existing_package_exports_remain_available():
+    assert PolyTensorRegression is not PolyTensorRegressor
+    for name in ('GPSymRegressor', 'VecSymRegressor', 'LLMSymRegressor',
+                 'RLRegressor', 'RLSymRegressor', 'TNLinear', 'TNTransformer',
+                 'PolyTensorRegression', 'PolyTensorRegressor'):
+        assert name in tnlearn.__all__
+        assert hasattr(tnlearn, name)
+
+
+@pytest.mark.parametrize('config', CONFIGS)
+def test_colleague_configs_fit_and_predict(config):
+    X, y = make_regression(n_samples=100, n_features=10, noise=0.1, random_state=1)
+    neuron = neuronseek_config_to_string(config)
+    # Two optimizer steps validate the public fit path without a benchmark run.
+    model = MLPRegressor(neuron, layers_list=[4], max_iter=2)
+    model.fit(X, y)
+    assert model.predict(X).shape == (100,)
+    assert np.isfinite(model.predict(X)).all()
+    assert np.isfinite(model.losses).all()
+
+
+def test_pure_and_interaction_terms_are_mathematically_distinct():
+    pure = BaseCustomNeuronLayer(2, 1, neuronseek_config_to_string(
+        dict(pure_indices=[2])), bias=False)
+    interaction = BaseCustomNeuronLayer(2, 1, neuronseek_config_to_string(
+        dict(interact_indices=[2])), bias=False)
+    with torch.no_grad():
+        for layer in (pure, interaction):
+            for parameter in layer.parameters():
+                parameter.fill_(1)
+    x = torch.tensor([[2., 3.]])
+    torch.testing.assert_close(pure(x), torch.tensor([[13.]]))
+    torch.testing.assert_close(interaction(x), torch.tensor([[25.]]))
+
+
+@pytest.mark.parametrize('device', ['cpu', 'cuda'])
+def test_cp_rank_preserves_independent_components_and_gradients(device):
+    if device == 'cuda' and not torch.cuda.is_available():
+        pytest.skip('CUDA is not available')
+    neuron = neuronseek_config_to_string(CONFIGS[0])
+    expr = sp.sympify(convert_pretty_to_innerproduct(neuron),
+                     locals={'InnerProduct': InnerProduct})
+    # Two pure terms plus 8 independent components for each interaction order.
+    assert len(sp.Add.make_args(expr)) == 2 + 8 + 8
+    assert len(expr.free_symbols - {sp.Symbol('x')}) == 2 + 8 * (2 + 3)
+    layer = BaseCustomNeuronLayer(2, 1, neuron, bias=False).to(device)
+    with torch.no_grad():
+        for parameter in layer.parameters():
+            parameter.fill_(1)
+    x = torch.tensor([[2., 3.], [1., 2.]], device=device)
+    # <1,x> + <1,x**2> + 8*<1,x>**2 + 8*<1,x>**3
+    expected = x.sum(1) + x.square().sum(1) + 8*x.sum(1)**2 + 8*x.sum(1)**3
+    torch.testing.assert_close(layer(x).flatten(), expected)
+    layer(x).sum().backward()
+    for parameter in layer.parameters():
+        assert parameter.grad is not None
+        assert torch.isfinite(parameter.grad).all()
+        assert parameter.grad.abs().sum() > 0
+
+
+def test_rank_one_and_missing_fields_keep_existing_format():
+    assert neuronseek_config_to_string(dict(pure_indices=[1], interact_indices=[2])) == (
+        '<w1, x>+<w2, x>*<w3, x>')
+    assert neuronseek_config_to_string({}) == ''
+    assert neuronseek_config_to_string(dict(pure_indices=[True, 0, -1, 2])) == '<w1, x**2>'
+
+
+@pytest.mark.parametrize('rank', [0, -1, 1.5, '8', True, None])
+def test_invalid_cp_rank_is_rejected(rank):
+    with pytest.raises(ValueError, match='rank'):
+        neuronseek_config_to_string(dict(interact_indices=[2], rank=rank))
+
+
+def test_export_paths_preserve_structure_without_training():
+    reg = PolyTensorRegressor(rank=2, poly_order=3, device='cpu')
+    reg.agent = SparseSearchAgent(input_dim=2, rank=2, max_order=3)
+    with torch.no_grad():
+        for gate in list(reg.agent.gates_pure) + list(reg.agent.gates_int):
+            gate.log_alpha.fill_(-100)
+        reg.agent.gates_pure[1].log_alpha.fill_(100)
+        reg.agent.gates_int[1].log_alpha.fill_(100)
+    expected = neuronseek_config_to_string(dict(
+        pure_indices=[2], interact_indices=[2], rank=2))
+    assert reg._export_current_neuron() == expected
+    assert reg.get_significant_polynomial() == expected
+    assert reg.structure_['pure_indices'] == reg.structure_['interact_indices'] == [2]
+    assert '@' not in reg.neuron
+
+
+def test_empty_search_exports_zero_and_builds_bias_only_mlp():
+    reg = PolyTensorRegressor(rank=1, poly_order=1, device='cpu')
+    reg.agent = SparseSearchAgent(input_dim=2, rank=1, max_order=1)
+    with torch.no_grad():
+        reg.agent.gates_pure[0].log_alpha.fill_(-100)
+        reg.agent.gates_int[0].log_alpha.fill_(-100)
+    assert reg.get_significant_polynomial() == reg._export_current_neuron() == '0'
+    layer = BaseCustomNeuronLayer(2, 3, reg.neuron, bias=False)
+    torch.testing.assert_close(layer(torch.randn(4, 2)), torch.zeros(4, 3))
+    X = np.ones((4, 2), dtype=np.float32)
+    model = MLPRegressor(reg.neuron, layers_list=[3], max_iter=2)
+    model.fit(X, np.ones(4))
+    assert model.predict(X).shape == (4,)
+
+
+@pytest.mark.parametrize('task_type', ['regression', 'classification'])
+@pytest.mark.parametrize('device', ['cpu', 'cuda'])
+def test_search_fit_export_callback_predict_and_refit(task_type, device):
+    if device == 'cuda' and not torch.cuda.is_available():
+        pytest.skip('CUDA is not available')
+    X = np.random.default_rng(1).normal(size=(9, 3)).astype(np.float32)
+    y = X[:, 0] + 3 if task_type == 'regression' else np.arange(9) % 2
+    callbacks = []
+    reg = PolyTensorRegressor(rank=2, poly_order=2, num_epochs=2, batch_size=4,
+                              device=device, random_state=1, task_type=task_type,
+                              track_callback=callbacks.append)
+    assert reg.fit(X, y) is reg
+    assert reg.neuron == neuronseek_config_to_string(reg.structure_)
+    assert reg.neuron == reg.get_significant_polynomial() == callbacks[-1]
+    assert reg.agent.bias.detach().abs().sum() > 0
+    assert np.isfinite(reg.logs_['loss']).all()
+    first = reg.predict(X)
+    assert first.shape == (9,)
+    assert torch.isfinite(first).all()
+    model = MLPRegressor(reg.neuron, layers_list=[3], max_iter=2)
+    model.fit(X, y)
+    assert np.isfinite(model.predict(X)).all()
+    reg.fit(X, y)
+    assert len(reg.logs_['loss']) == 2
+    assert len(callbacks) == 4
+    torch.testing.assert_close(first, reg.predict(X))
+
+
+@pytest.mark.parametrize('kwargs', [dict(method='tucker'), dict(batch_size=1),
+                                    dict(rank=0), dict(structure_threshold=2)])
+def test_unsupported_search_settings_are_rejected(kwargs):
+    with pytest.raises(ValueError):
+        PolyTensorRegressor(**kwargs)
+
+
+def test_singleton_and_misaligned_training_data_are_rejected():
+    reg = PolyTensorRegressor(device='cpu')
+    with pytest.raises(ValueError, match='at least two'):
+        reg.fit(np.ones((1, 2)), np.ones(1))
+    with pytest.raises(ValueError, match='same sample count'):
+        reg.fit(np.ones((3, 2)), np.ones(2))

--- a/tnlearn/__init__.py
+++ b/tnlearn/__init__.py
@@ -22,7 +22,7 @@ from tnlearn.mlpclassifier import MLPClassifier
 from tnlearn.preprocessing import DataPreprocessor
 from tnlearn.base import BaseModel
 from tnlearn.base1 import BaseModel1
-from tnlearn.poly_regressor import PolyTensorRegression
+from tnlearn.poly_regressor import PolyTensorRegression, PolyTensorRegressor
 
 from tnlearn.drsr import LLMSymRegressor
 from tnlearn.rl_regressor import RLRegressor, RLSymRegressor
@@ -39,6 +39,7 @@ __all__ = [
     'BaseModel',
     'BaseModel1',
     'PolyTensorRegression', # about to be deprecated
+    'PolyTensorRegressor',
     'LLMSymRegressor',           
     'RLRegressor', # legacy
     'RLSymRegressor',                   

--- a/tnlearn/operator/inner_product.py
+++ b/tnlearn/operator/inner_product.py
@@ -237,7 +237,7 @@ def parameterize_expression(expr, include_bias=False):
         if pt != 0:
             new_terms.append(pt)
     if not new_terms:
-        return 0
+        return sympify(0)
     return Add(*new_terms) if len(new_terms) > 1 else new_terms[0]
 
 
@@ -364,8 +364,12 @@ def evaluate_expression(expr, x_tensor, param_dict, out_dim):
             else:
                 subs[sym_obj] = param
         val = eval_sympy_expr(expr, subs)
-        if val.dim() == 1:
+        if val.dim() == 0:
+            val = val.reshape(1, 1)
+        elif val.dim() == 1:
             val = val.unsqueeze(-1)
+        if val.size(0) == 1:
+            val = val.expand(batch, -1)
         results.append(val)
     return torch.cat(results, dim=1)
 
@@ -377,12 +381,13 @@ def neuronseek_config_to_string(config: dict) -> str:
     The expression consists of a polynomial stream, an interaction stream, and an optional periodic stream.
     Pure terms are represented as <w_i, x> for k=1 and <w_i, x**k> for k>1.
     Interaction terms are represented as products of linear inner products <w_j, x>
-    for each interaction order m in `interact_indices`, using a rank-1 CP decomposition.
+    for each interaction order m in `interact_indices`, summed over `rank`
+    independent CP components (default: 1).
     If `periodic` is True, a term <w_i, sin(x)> is appended.
 
     This function performs input validation and gracefully handles missing fields,
-    invalid data types, and non-positive orders. The `rank` parameter is currently
-    ignored, as only rank-1 decompositions are used for interaction terms.
+    invalid data types, and non-positive orders. Each CP component uses distinct
+    weight symbols so downstream parameterization preserves the requested rank.
 
     Args:
         config (dict): A dictionary containing the following optional keys:
@@ -395,7 +400,7 @@ def neuronseek_config_to_string(config: dict) -> str:
                 is fully supported; other values trigger a warning but still
                 generate an expression using inner products. Defaults to
                 'cp_inner_product'.
-            - rank (int): CP rank; currently ignored.
+            - rank (int): Positive CP rank. Defaults to 1.
             - periodic (bool): If True, includes a periodic term <w_i, sin(x)>.
                 Defaults to False.
 
@@ -405,21 +410,22 @@ def neuronseek_config_to_string(config: dict) -> str:
 
     Raises:
         TypeError: If `pure_indices` or `interact_indices` is present but not a list.
+        ValueError: If `rank` is not a positive integer.
 
     Examples:
         >>> config = {'pure_indices': [1, 2], 'interact_indices': [2, 3]}
         >>> neuronseek_config_to_string(config)
-        '<w1,x>+<w2,x**2>+<w3,x>*<w4,x>+<w5,x>*<w6,x>*<w7,x>'
+        '<w1, x>+<w2, x**2>+<w3, x>*<w4, x>+<w5, x>*<w6, x>*<w7, x>'
 
         >>> config = {'pure_indices': [1], 'interact_indices': [2], 'periodic': True}
         >>> neuronseek_config_to_string(config)
-        '<w1,x>+<w2,x>*<w3,x>+<w4,sin(x)>'
+        '<w1, x>+<w2, x>*<w3, x>+<w4, sin(x)>'
 
         >>> neuronseek_config_to_string({})
         ''
 
         >>> neuronseek_config_to_string({'pure_indices': [0, -1, 2]})
-        '<w1,x**2>'
+        '<w1, x**2>'
 
         >>> neuronseek_config_to_string({'pure_indices': 'not a list'})
         Traceback (most recent call last):
@@ -428,6 +434,10 @@ def neuronseek_config_to_string(config: dict) -> str:
     """
 
     # ---- Safely retrieve and validate fields ----
+    rank = config.get('rank', 1)
+    if isinstance(rank, bool) or not isinstance(rank, int) or rank < 1:
+        raise ValueError("'rank' must be a positive integer")
+
     pure = config.get('pure_indices')
     if pure is None:
         pure = []
@@ -444,7 +454,7 @@ def neuronseek_config_to_string(config: dict) -> str:
     def is_valid_order(v: any) -> bool:
         """Return True if v is a positive integer."""
         try:
-            return isinstance(v, int) and v > 0
+            return isinstance(v, int) and not isinstance(v, bool) and v > 0
         except Exception:
             return False
 
@@ -457,7 +467,7 @@ def neuronseek_config_to_string(config: dict) -> str:
         import warnings
         warnings.warn(
             f"interaction_form '{form}' is not fully supported; "
-            "using cp_inner_product representation (rank 1).",
+            f"using cp_inner_product representation (rank {rank}).",
             UserWarning
         )
 
@@ -473,13 +483,14 @@ def neuronseek_config_to_string(config: dict) -> str:
             parts.append(f"<w{w_idx}, x**{k}>")
         w_idx += 1
 
-    # Interaction stream: each order m gives product of m linear inner products
+    # A rank-R order-m CP term is a sum of R products of m inner products.
     for m in inter:
-        factors = []
-        for _ in range(m):
-            factors.append(f"<w{w_idx}, x>")
-            w_idx += 1
-        parts.append("*".join(factors))
+        for _ in range(rank):
+            factors = []
+            for _ in range(m):
+                factors.append(f"<w{w_idx}, x>")
+                w_idx += 1
+            parts.append("*".join(factors))
 
     # Periodic stream: if enabled, add <w_i, sin(x)>
     if config.get('periodic', False):

--- a/tnlearn/poly_regressor.py
+++ b/tnlearn/poly_regressor.py
@@ -417,6 +417,8 @@ class PolyTensorRegressor(nn.Module):
     ``PolyTensorRegression`` remains the separate legacy CP/Tucker estimator.
     This searcher supports CP only and expects at least two finite samples.
     Classification labels must be integers in ``[0, num_classes)``.
+    ``reg_lambda_w`` controls the core weight L1 penalty; setting it to zero
+    disables weight regularization. Optimizer weight decay is not applied.
     """
 
     def __init__(self,
@@ -525,9 +527,9 @@ class PolyTensorRegressor(nn.Module):
 
         loss_fn = nn.CrossEntropyLoss() if self.task_type == 'classification' else nn.MSELoss()
         optimizer = torch.optim.Adam([
-            {'params': self.agent.core.coeffs_pure.parameters(), 'lr': self.learning_rate * 0.5, 'weight_decay': 1e-4},
+            {'params': self.agent.core.coeffs_pure.parameters(), 'lr': self.learning_rate * 0.5},
             {'params': [self.agent.bias], 'lr': self.learning_rate * 0.5},
-            {'params': self.agent.core.factors.parameters(), 'lr': self.learning_rate, 'weight_decay': 1e-5},
+            {'params': self.agent.core.factors.parameters(), 'lr': self.learning_rate},
             {'params': list(self.agent.bn_pure.parameters()) + list(self.agent.bn_int.parameters()), 'lr': self.learning_rate},
             {'params': list(self.agent.gates_pure.parameters()) + list(self.agent.gates_int.parameters()), 'lr': self.learning_rate},
         ])

--- a/tnlearn/poly_regressor.py
+++ b/tnlearn/poly_regressor.py
@@ -8,6 +8,8 @@ from itertools import product
 from torch.optim.lr_scheduler import CosineAnnealingLR
 import random
 
+from tnlearn.operator.inner_product import neuronseek_config_to_string
+
 def random_seed(seed):
     r"""Set the random seed for reproducibility of experiments.
 
@@ -278,3 +280,371 @@ class PolyTensorRegression(nn.Module):
                 return predicted_labels
             else:
                 return outputs.view(-1)
+
+
+class DualStreamInteractionLayer(nn.Module):
+    """Dual-stream polynomial interaction core from NeuronSeek-TD."""
+
+    def __init__(self, input_dim: int, num_classes: int, rank: int, poly_order: int):
+        super().__init__()
+        self.rank = rank
+        self.num_classes = num_classes
+        self.poly_order = poly_order
+
+        self.factors = nn.ModuleList()
+        for order in range(1, poly_order + 1):
+            order_params = nn.ParameterList([
+                nn.Parameter(torch.empty(input_dim, rank, num_classes))
+                for _ in range(order)
+            ])
+            self.factors.append(order_params)
+
+        # Stage-1 proxy weights; the MLP learns its own weights after export.
+        self.coeffs_pure = nn.ParameterList([
+            nn.Parameter(torch.empty(input_dim, num_classes))
+            for _ in range(poly_order)
+        ])
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        for order_params in self.factors:
+            for param in order_params:
+                nn.init.normal_(param, std=0.05)
+        for param in self.coeffs_pure:
+            nn.init.normal_(param, std=0.05)
+
+    def get_pure_term(self, x: torch.Tensor, order_idx: int) -> torch.Tensor:
+        order = order_idx + 1
+        term = x if order == 1 else x.pow(order)
+        return term @ self.coeffs_pure[order_idx]
+
+    def get_interaction_term(self, x: torch.Tensor, order_idx: int) -> torch.Tensor:
+        factors = self.factors[order_idx]
+        projections = [torch.einsum('bd, drc -> brc', x, factor) for factor in factors]
+        combined = projections[0]
+        for projection in projections[1:]:
+            combined = combined * projection
+        return torch.sum(combined, dim=1)
+
+
+class L0Gate(nn.Module):
+    """Hard-concrete L0 gate used to prune polynomial orders."""
+
+    def __init__(self, temperature=0.66, limit_l=-0.1, limit_r=1.1, init_prob=0.9):
+        super().__init__()
+        self.temp = temperature
+        self.limit_l = limit_l
+        self.limit_r = limit_r
+        init_val = np.log(init_prob / (1 - init_prob))
+        self.log_alpha = nn.Parameter(torch.tensor([init_val], dtype=torch.float32))
+
+    def forward(self, x, training=True):
+        if training:
+            u = torch.rand_like(self.log_alpha)
+            s = torch.sigmoid((torch.log(u + 1e-8) - torch.log(1 - u + 1e-8) + self.log_alpha) / self.temp)
+            s = s * (self.limit_r - self.limit_l) + self.limit_l
+        else:
+            s = torch.sigmoid(self.log_alpha) * (self.limit_r - self.limit_l) + self.limit_l
+        z = torch.clamp(s, min=0.0, max=1.0)
+        return x * z
+
+    def regularization_term(self):
+        log_ratio = torch.log(torch.tensor(-self.limit_l / self.limit_r, device=self.log_alpha.device, dtype=self.log_alpha.dtype))
+        return torch.sigmoid(self.log_alpha - self.temp * log_ratio)
+
+    def get_prob(self):
+        return torch.sigmoid(self.log_alpha).item()
+
+
+class SparseSearchAgent(nn.Module):
+    """Differentiable NeuronSeek-TD structure search agent."""
+
+    def __init__(self, input_dim=10, num_classes=1, rank=8, max_order=5):
+        super().__init__()
+        self.input_dim = input_dim
+        self.max_order = max_order
+        self.core = DualStreamInteractionLayer(input_dim, num_classes, rank, max_order)
+        self.bias = nn.Parameter(torch.zeros(num_classes))
+        self.gates_pure = nn.ModuleList([L0Gate() for _ in range(max_order)])
+        self.gates_int = nn.ModuleList([L0Gate() for _ in range(max_order)])
+        self.bn_pure = nn.ModuleList(nn.BatchNorm1d(num_classes, affine=True) for _ in range(max_order))
+        self.bn_int = nn.ModuleList(nn.BatchNorm1d(num_classes, affine=True) for _ in range(max_order))
+
+    def forward(self, x, training=True):
+        output = self.bias.unsqueeze(0).expand(x.size(0), -1).clone()
+
+        for i, gate in enumerate(self.gates_pure):
+            term = self.core.get_pure_term(x, i)
+            output = output + gate(self.bn_pure[i](term), training=training)
+
+        for i, gate in enumerate(self.gates_int):
+            term = self.core.get_interaction_term(x, i)
+            output = output + gate(self.bn_int[i](term), training=training)
+
+        return output
+
+    def get_structure(self, threshold=0.5):
+        pure_active = []
+        interact_active = []
+        with torch.no_grad():
+            for i, gate in enumerate(self.gates_pure):
+                if gate.regularization_term() > threshold:
+                    pure_active.append(i + 1)
+            for i, gate in enumerate(self.gates_int):
+                if gate.regularization_term() > threshold:
+                    interact_active.append(i + 1)
+        return pure_active, interact_active
+
+    def calculate_regularization(self):
+        reg_loss = 0.0
+        for gate in self.gates_pure:
+            reg_loss = reg_loss + gate.regularization_term()
+        for gate in self.gates_int:
+            reg_loss = reg_loss + gate.regularization_term()
+        return reg_loss
+
+
+class PolyTensorRegressor(nn.Module):
+    """
+    NeuronSeek-TD stage-1 polynomial term searcher for tnlearn.
+
+    The search process follows the revised NeuronSeek dual-stream design to
+    select active polynomial orders with differentiable L0 gates. tnlearn's
+    second stage learns its own layer weights. The exported ``neuron`` uses
+    inner products, retaining pure/interaction orders and CP rank, without
+    transferring fitted weights, gates, or batch-normalization parameters.
+
+    ``PolyTensorRegression`` remains the separate legacy CP/Tucker estimator.
+    This searcher supports CP only and expects at least two finite samples.
+    Classification labels must be integers in ``[0, num_classes)``.
+    """
+
+    def __init__(self,
+                 rank=8,
+                 poly_order=5,
+                 method='cp',
+                 reg_lambda_w=0.01,
+                 reg_lambda_c=0.05,
+                 num_epochs=100,
+                 learning_rate=0.01,
+                 batch_size=64,
+                 task_type='regression',
+                 num_classes: Optional[int] = None,
+                 device: Optional[torch.device] = None,
+                 track_callback=None,
+                 random_state: Optional[int] = None,
+                 structure_threshold=0.5):
+        super().__init__()
+        for name, value in [('rank', rank), ('poly_order', poly_order),
+                            ('num_epochs', num_epochs), ('batch_size', batch_size)]:
+            if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+                raise ValueError(f'{name} must be a positive integer')
+        if batch_size < 2:
+            raise ValueError('batch_size must be at least 2 for batch normalization')
+        if method != 'cp':
+            raise ValueError("NeuronSeek supports method='cp' only")
+        if task_type not in ('regression', 'classification'):
+            raise ValueError("task_type must be 'regression' or 'classification'")
+        if not 0 <= structure_threshold <= 1:
+            raise ValueError('structure_threshold must be between 0 and 1')
+        if learning_rate <= 0 or reg_lambda_w < 0 or reg_lambda_c < 0:
+            raise ValueError('learning_rate must be positive and regularization non-negative')
+        if random_state is not None:
+            random_seed(random_state)
+        self.rank = rank
+        self.poly_order = poly_order
+        self.method = method
+        self.reg_lambda_w = reg_lambda_w
+        self.reg_lambda_c = reg_lambda_c
+        self.num_epochs = num_epochs
+        self.learning_rate = learning_rate
+        self.batch_size = batch_size
+        self.task_type = task_type
+        self.num_classes = num_classes
+        self.device = device if device else torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.track_callback = track_callback
+        self.random_state = random_state
+        self.structure_threshold = structure_threshold
+        self.agent = None
+        self.neuron = None
+        self.structure_ = None
+        self.logs_ = {'loss': [], 'lambda_val': []}
+
+    def _prepare_tensors(self, X, y):
+        if not isinstance(X, torch.Tensor):
+            X_tensor = torch.tensor(X, dtype=torch.float32, device=self.device)
+        else:
+            X_tensor = X.to(self.device, dtype=torch.float32)
+        if X_tensor.ndim < 2 or X_tensor.size(0) < 2:
+            raise ValueError('X must contain at least two samples with features')
+        X_tensor = X_tensor.reshape(X_tensor.size(0), -1)
+        if X_tensor.size(1) == 0 or not torch.isfinite(X_tensor).all():
+            raise ValueError('X must contain finite, nonempty features')
+
+        if not isinstance(y, torch.Tensor):
+            y_tensor = torch.tensor(y, device=self.device)
+        else:
+            y_tensor = y.to(self.device)
+
+        if y_tensor.ndim not in (1, 2) or (y_tensor.ndim == 2 and y_tensor.size(1) != 1):
+            raise ValueError('y must have shape (n_samples,) or (n_samples, 1)')
+        if y_tensor.size(0) != X_tensor.size(0) or not torch.isfinite(y_tensor).all():
+            raise ValueError('y must be finite and have the same sample count as X')
+
+        if self.task_type == 'classification':
+            if (y_tensor < 0).any() or not torch.equal(y_tensor, y_tensor.long()):
+                raise ValueError('classification labels must be non-negative integers')
+            y_tensor = y_tensor.long().view(-1)
+            if self.num_classes is None:
+                self.num_classes = int(y_tensor.max().item()) + 1
+            if self.num_classes < 2 or y_tensor.max() >= self.num_classes:
+                raise ValueError('num_classes must exceed all labels and be at least 2')
+        else:
+            y_tensor = y_tensor.float().view(-1, 1)
+            self.num_classes = 1
+
+        return X_tensor, y_tensor
+
+    def fit(self, X, y, view_training_process=False):
+        X_tensor, y_tensor = self._prepare_tensors(X, y)
+        if self.random_state is not None:
+            random_seed(self.random_state)
+        self.logs_ = {'loss': [], 'lambda_val': []}
+        self.structure_ = None
+        self.neuron = None
+        input_dim = X_tensor.shape[1]
+        self.n_features_in_ = input_dim
+        output_dim = int(self.num_classes or 1)
+
+        self.agent = SparseSearchAgent(
+            input_dim=input_dim,
+            num_classes=output_dim,
+            rank=self.rank,
+            max_order=self.poly_order,
+        ).to(self.device)
+
+        loss_fn = nn.CrossEntropyLoss() if self.task_type == 'classification' else nn.MSELoss()
+        optimizer = torch.optim.Adam([
+            {'params': self.agent.core.coeffs_pure.parameters(), 'lr': self.learning_rate * 0.5, 'weight_decay': 1e-4},
+            {'params': [self.agent.bias], 'lr': self.learning_rate * 0.5},
+            {'params': self.agent.core.factors.parameters(), 'lr': self.learning_rate, 'weight_decay': 1e-5},
+            {'params': list(self.agent.bn_pure.parameters()) + list(self.agent.bn_int.parameters()), 'lr': self.learning_rate},
+            {'params': list(self.agent.gates_pure.parameters()) + list(self.agent.gates_int.parameters()), 'lr': self.learning_rate},
+        ])
+        scheduler = CosineAnnealingLR(optimizer, T_max=self.num_epochs, eta_min=1e-5)
+
+        batch_size = min(self.batch_size, len(X_tensor))
+        drop_last = len(X_tensor) > batch_size
+        dataset = torch.utils.data.TensorDataset(X_tensor, y_tensor)
+        dataloader = torch.utils.data.DataLoader(dataset, batch_size=batch_size, shuffle=True, drop_last=drop_last)
+
+        warmup_end = int(self.num_epochs * 0.25)
+        anneal_end = max(warmup_end + 1, int(self.num_epochs * 0.75))
+        max_lambda = self.reg_lambda_c
+
+        self.train()
+        losses = []
+        for epoch in range(self.num_epochs):
+            current_lambda = 0.0
+            if epoch >= warmup_end:
+                if epoch < anneal_end:
+                    progress = (epoch - warmup_end) / (anneal_end - warmup_end)
+                    current_lambda = max_lambda * progress
+                else:
+                    current_lambda = max_lambda
+
+            is_frozen = epoch < warmup_end
+            for param in self.agent.gates_pure.parameters():
+                param.requires_grad = not is_frozen
+            for param in self.agent.gates_int.parameters():
+                param.requires_grad = not is_frozen
+
+            total_loss = 0.0
+            for batch_x, batch_y in dataloader:
+                optimizer.zero_grad()
+                preds = self.agent(batch_x, training=True)
+                task_loss = loss_fn(preds, batch_y)
+                weight_penalty = sum(p.abs().mean() for p in self.agent.core.parameters())
+                reg_loss = (current_lambda * self.agent.calculate_regularization()
+                            + self.reg_lambda_w * weight_penalty)
+                loss = task_loss + reg_loss
+                loss.backward()
+                torch.nn.utils.clip_grad_norm_(self.agent.parameters(), max_norm=1.0)
+                optimizer.step()
+                total_loss += loss.item()
+
+            scheduler.step()
+            epoch_loss = total_loss / max(1, len(dataloader))
+            losses.append(epoch_loss)
+            self.logs_['loss'].append(epoch_loss)
+            self.logs_['lambda_val'].append(current_lambda)
+
+            if self.track_callback:
+                self.track_callback(self._export_current_neuron())
+
+            print(f'Epoch {epoch + 1}/{self.num_epochs}, Loss: {epoch_loss:.4f}, Lambda: {current_lambda:.4f}')
+
+        self.structure_ = self.get_structure_info()
+        self.neuron = neuronseek_config_to_string(self.structure_) or '0'
+
+        if view_training_process:
+            import matplotlib.pyplot as plt
+
+            plt.plot(losses)
+            plt.show()
+
+        return self
+
+    def forward(self, X):
+        if self.agent is None:
+            raise RuntimeError("PolyTensorRegressor must be fitted before calling forward().")
+        if not isinstance(X, torch.Tensor):
+            X_tensor = torch.tensor(X, dtype=torch.float32, device=self.device)
+        else:
+            X_tensor = X.to(self.device, dtype=torch.float32)
+        X_tensor = X_tensor.view(X_tensor.size(0), -1)
+        output = self.agent(X_tensor, training=self.training)
+        return output, self.agent.calculate_regularization()
+
+    def predict(self, X):
+        if self.agent is None:
+            raise RuntimeError("PolyTensorRegressor must be fitted before calling predict().")
+        self.eval()
+        with torch.no_grad():
+            if not isinstance(X, torch.Tensor):
+                X_tensor = torch.tensor(X, dtype=torch.float32, device=self.device)
+            else:
+                X_tensor = X.to(self.device, dtype=torch.float32)
+            X_tensor = X_tensor.view(X_tensor.size(0), -1)
+            outputs = self.agent(X_tensor, training=False)
+            if self.task_type == 'classification':
+                return torch.argmax(torch.softmax(outputs, dim=1), dim=1)
+            return outputs.view(-1)
+
+    def get_structure_info(self):
+        if self.agent is None:
+            return {
+                'type': 'neuronseek',
+                'pure_indices': [],
+                'interact_indices': [],
+                'rank': self.rank,
+                'interaction_form': 'cp_inner_product',
+            }
+        pure_indices, interact_indices = self.agent.get_structure(threshold=self.structure_threshold)
+        return {
+            'type': 'neuronseek',
+            'pure_indices': pure_indices,
+            'interact_indices': interact_indices,
+            'rank': self.rank,
+            'interaction_form': 'cp_inner_product',
+        }
+
+    def get_significant_polynomial(self):
+        if self.structure_ is None:
+            self.structure_ = self.get_structure_info()
+        self.neuron = neuronseek_config_to_string(self.structure_) or '0'
+        return self.neuron
+
+    def _export_current_neuron(self):
+        structure = self.get_structure_info()
+        return neuronseek_config_to_string(structure) or '0'


### PR DESCRIPTION
Adds `PolyTensorRegressor` for NeuronSeek stage-one structure search and exports its results through `neuronseek_config_to_string`, compatible with the current default `MLPRegressor` mode. Pure and interaction terms remain distinct: pure order 2 exports an inner product with `x**2`, while interaction order 2 exports a product of linear inner products. CP rank now controls the number of independently parameterized components instead of being ignored.

The existing `PolyTensorRegression` implementation and current package exports remain available. Final, callback and explicit polynomial exports use the same conversion path. All-pruned searches produce a bias-only expression, and constant expressions broadcast across the batch. The search optimizer includes its bias, applies the exposed weight regularizer, validates unsupported inputs, and resets state when refitted.

Includes runnable search/manual-configuration examples, focused regression tests, and a Python 3.10/3.12 CPU test workflow.

Validation on Python 3.11 / PyTorch 2.7.1:

- `python -m pytest tests/test_neuronseek.py -q`: **26 passed**, with CPU and CUDA cases executed; no skips.
- `python examples/example_neuronseek_configs.py`: all four supplied configurations completed the default 300 iterations and `[50, 30, 10]` hidden layers; predictions and losses were finite.
- Syntax and diff checks passed. The existing `PolyTensorRegression` class is unchanged.

This resubmission is based on current upstream `main` (`0bb9af6`) and replaces the unmerged NeuronSeek proposals in #17 and #18. Validation covers software integration, not predictive-performance claims.